### PR TITLE
프로필 스크린 UI 수정 

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,38 +40,4 @@ module.exports = defineConfig([
       },
     },
   },
-  {
-    rules: {
-      'import/order': [
-        'error',
-        {
-          groups: [
-            'builtin',
-            'external',
-            'internal',
-            'parent',
-            'sibling',
-            'index',
-          ],
-          'newlines-between': 'always',
-          alphabetize: {
-            order: 'asc',
-            caseInsensitive: true,
-          },
-        },
-      ],
-      'import/no-duplicates': 'error',
-    },
-    settings: {
-      'import/resolver': {
-        alias: {
-          map: [
-            ['@/src', './src'],
-            ['@', './src'],
-          ],
-          extensions: ['.ts', '.tsx', '.js', '.jsx'],
-        },
-      },
-    },
-  },
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5610,9 +5610,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001745",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
-      "integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
+      "version": "1.0.30001746",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001746.tgz",
+      "integrity": "sha512-eA7Ys/DGw+pnkWWSE/id29f2IcPHVoE8wxtvE5JdvD2V28VTDPy1yEeo11Guz0sJ4ZeGRcm3uaTcAqK1LXaphA==",
       "funding": [
         {
           "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@types/react": "~19.1.10",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~10.0.0",
+        "eslint-import-resolver-alias": "^1.1.2",
         "eslint-plugin-import": "^2.32.0",
         "husky": "^9.1.7",
         "json-server": "^1.0.0-beta.3",
@@ -6790,6 +6791,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-import-resolver-alias": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
+      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      },
+      "peerDependencies": {
+        "eslint-plugin-import": ">=1.4.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9001,14 +9001,13 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.1.tgz",
-      "integrity": "sha512-Gn8BWUdrTzf9XUJAvqIYP7QnSC3mKs8QjQdGdJ7HmBemzZo14wj/OVmmAwgxDX/7WhFEjboybL4VhXGIQYPlOA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
-        "generator-function": "^2.0.0",
         "get-proto": "^1.0.0",
         "has-tostringtag": "^1.0.2",
         "safe-regex-test": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/react": "~19.1.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~10.0.0",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.32.0",
     "husky": "^9.1.7",
     "json-server": "^1.0.0-beta.3",

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -98,6 +98,7 @@ const styles = StyleSheet.create({
     fontSize: 18,
     color: theme.colors.text.sub,
     transform: [{ rotate: '0deg' }],
+    marginTop: -6,
   },
   overlay: {
     flex: 1,

--- a/src/screens/profile/components/badge/badge.tsx
+++ b/src/screens/profile/components/badge/badge.tsx
@@ -5,7 +5,15 @@ import { BadgeStyles } from './badge_style';
 
 interface BadgeProps {
   text: string;
-  variant?: 'primary' | 'secondary' | 'success' | 'warning' | 'danger';
+  variant?:
+    | 'primary'
+    | 'secondary'
+    | 'success'
+    | 'warning'
+    | 'danger'
+    | 'gold'
+    | 'silver'
+    | 'bronze';
   size?: 'small' | 'medium' | 'large';
 }
 
@@ -46,6 +54,12 @@ export const Badge = ({
         return BadgeStyles.warning;
       case 'danger':
         return BadgeStyles.danger;
+      case 'gold':
+        return BadgeStyles.gold;
+      case 'silver':
+        return BadgeStyles.silver;
+      case 'bronze':
+        return BadgeStyles.bronze;
       default:
         return BadgeStyles.primary;
     }

--- a/src/screens/profile/components/badge/badge_style.ts
+++ b/src/screens/profile/components/badge/badge_style.ts
@@ -6,42 +6,45 @@ export const BadgeStyles = StyleSheet.create({
   container: {
     paddingHorizontal: spacing.spacing2,
     paddingVertical: spacing.spacing1,
-    borderRadius: spacing.spacing1,
+    borderRadius: spacing.spacing3,
     alignItems: 'center',
     justifyContent: 'center',
   },
 
   small: {
-    paddingHorizontal: spacing.spacing1,
-    paddingVertical: spacing.spacing1 / 2,
-    borderRadius: spacing.spacing1 / 2,
+    paddingHorizontal: spacing.spacing2,
+    paddingVertical: spacing.spacing1,
+    borderRadius: spacing.spacing3,
   },
 
   medium: {
     paddingHorizontal: spacing.spacing2,
     paddingVertical: spacing.spacing1,
-    borderRadius: spacing.spacing1,
+    borderRadius: spacing.spacing3,
   },
 
   large: {
     paddingHorizontal: spacing.spacing4,
     paddingVertical: spacing.spacing2,
-    borderRadius: spacing.spacing2,
+    borderRadius: spacing.spacing4,
   },
 
   textSmall: {
     ...typography.text.caption,
     color: colors.text.main,
+    fontWeight: '600',
   },
 
   textMedium: {
     ...typography.text.bodySmall,
     color: colors.text.main,
+    fontWeight: '600',
   },
 
   textLarge: {
     ...typography.text.body,
     color: colors.text.main,
+    fontWeight: '600',
   },
 
   primary: {
@@ -63,5 +66,17 @@ export const BadgeStyles = StyleSheet.create({
 
   danger: {
     backgroundColor: colors.error,
+  },
+
+  gold: {
+    backgroundColor: '#F4E4BC',
+  },
+
+  silver: {
+    backgroundColor: '#E8E8E8',
+  },
+
+  bronze: {
+    backgroundColor: '#E6D2B8',
   },
 });

--- a/src/screens/profile/components/profileHeader/index.tsx
+++ b/src/screens/profile/components/profileHeader/index.tsx
@@ -2,6 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { memo } from 'react';
 import { View, Text } from 'react-native';
 
+import { Badge } from '@/src/screens/profile/components/badge/badge';
 import { theme } from '@/src/theme';
 import { UserProfile } from '@/src/types/profile';
 import { formatDate } from '@/src/utils/date';
@@ -9,13 +10,35 @@ import { formatDate } from '@/src/utils/date';
 import styles from '../../profile_style';
 
 export default memo(function ProfileHeader({ user }: { user: UserProfile }) {
+  const getSkillLevelBadge = (skillLevel: string) => {
+    switch (skillLevel) {
+      case 'PRO':
+        return { variant: 'gold' as const, text: '프로' };
+      case 'SEMI_PRO':
+        return { variant: 'silver' as const, text: '세미프로' };
+      case 'AMATEUR':
+        return { variant: 'bronze' as const, text: '아마추어' };
+      default:
+        return { variant: 'bronze' as const, text: '아마추어' };
+    }
+  };
+
+  const skillBadge = getSkillLevelBadge(user.skillLevel);
+
   return (
     <View style={styles.profileHeader}>
       <View style={styles.profileAvatar}>
         <Ionicons name="person" size={48} color={theme.colors.grass[500]} />
       </View>
       <View style={styles.profileInfo}>
-        <Text style={styles.profileName}>{user.name}</Text>
+        <View style={[styles.nameContainer]}>
+          <Text style={styles.profileName}>{user.name}</Text>
+          <Badge
+            text={skillBadge.text}
+            variant={skillBadge.variant}
+            size="small"
+          />
+        </View>
         <Text style={styles.profileUniversity}>{user.university}</Text>
         <Text style={styles.profileDetails}>
           {formatDate(user.createdAt)} 가입

--- a/src/screens/profile/components/settingTab/setting_items.ts
+++ b/src/screens/profile/components/settingTab/setting_items.ts
@@ -1,12 +1,14 @@
 import { router } from 'expo-router';
-import { Linking } from 'react-native';
+import { Alert, Linking } from 'react-native';
 
 import { EXTERNAL_LINKS } from '@/src/constants/external_links';
 import { ROUTES } from '@/src/constants/routes';
 import { theme } from '@/src/theme';
 import type { SettingItem } from '@/src/types';
 
-export const defaultSettingsItems: SettingItem[] = [
+export const getDefaultSettingsItems = (
+  logout: () => Promise<void>
+): SettingItem[] => [
   {
     key: 'edit-profile',
     label: '개인정보 수정',
@@ -50,7 +52,19 @@ export const defaultSettingsItems: SettingItem[] = [
     key: 'logout',
     label: '로그아웃',
     color: theme.colors.error,
-    onPress: () => {},
+    onPress: () => {
+      Alert.alert('로그아웃', '정말 로그아웃하시겠습니까?', [
+        {
+          text: '취소',
+          style: 'cancel',
+        },
+        {
+          text: '로그아웃',
+          style: 'destructive',
+          onPress: logout,
+        },
+      ]);
+    },
     showChevron: false,
   },
 ];

--- a/src/screens/profile/edit/ProfileForm.tsx
+++ b/src/screens/profile/edit/ProfileForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity } from 'react-native';
 
+import { Dropdown } from '@/src/components/dropdown';
 import { UserProfile, UpdateProfileRequest } from '@/src/types/profile';
 
 import { styles } from './ProfileFormStyle';
@@ -44,6 +45,21 @@ export function ProfileForm({
     }
   };
 
+  const convertKoreanToPosition = (korean: string) => {
+    switch (korean) {
+      case '골키퍼':
+        return '골키퍼';
+      case '수비수':
+        return '수비수';
+      case '미드필더':
+        return '미드필더';
+      case '공격수':
+        return '공격수';
+      default:
+        return korean;
+    }
+  };
+
   const [formData, setFormData] = useState({
     name: initialData.name || '',
     skillLevel: convertSkillLevelToKorean(initialData.skillLevel || 'AMATEUR'),
@@ -55,12 +71,6 @@ export function ProfileForm({
 
   const validateForm = () => {
     const newErrors: Record<string, string> = {};
-
-    if (!formData.name.trim()) {
-      newErrors.name = '이름을 입력해주세요.';
-    } else if (formData.name.length < 2 || formData.name.length > 100) {
-      newErrors.name = '이름은 2~100자 사이여야 합니다.';
-    }
 
     if (formData.skillLevel && formData.skillLevel.length > 4) {
       newErrors.skillLevel = '실력은 4자 이하여야 합니다.';
@@ -80,7 +90,13 @@ export function ProfileForm({
 
   const handleSave = () => {
     if (validateForm()) {
-      onSave(formData);
+      const dataToSave = {
+        name: initialData.name, // 원본 이름 유지
+        skillLevel: formData.skillLevel,
+        position: convertKoreanToPosition(formData.position),
+        bio: formData.bio,
+      };
+      onSave(dataToSave);
     }
   };
 
@@ -96,14 +112,13 @@ export function ProfileForm({
       <Text style={styles.sectionTitle}>프로필 수정</Text>
 
       <View style={styles.inputGroup}>
-        <Text style={styles.label}>이름 *</Text>
+        <Text style={styles.label}>이름</Text>
         <TextInput
-          style={[styles.input, errors.name && styles.inputError]}
+          style={[styles.input, styles.inputDisabled]}
           value={formData.name}
-          onChangeText={value => updateField('name', value)}
-          placeholder="이름을 입력하세요"
+          editable={false}
+          placeholder="이름"
         />
-        {errors.name && <Text style={styles.errorText}>{errors.name}</Text>}
       </View>
 
       <View style={styles.inputGroup}>
@@ -137,11 +152,11 @@ export function ProfileForm({
 
       <View style={styles.inputGroup}>
         <Text style={styles.label}>포지션</Text>
-        <TextInput
-          style={[styles.input, errors.position && styles.inputError]}
-          value={formData.position}
-          onChangeText={value => updateField('position', value)}
-          placeholder="포지션을 입력하세요 (예: 공격수, 미드필더, 수비수)"
+        <Dropdown
+          items={['골키퍼', '수비수', '미드필더', '공격수'] as const}
+          value={formData.position || null}
+          onChange={value => updateField('position', value)}
+          placeholder="포지션을 선택하세요"
         />
         {errors.position && (
           <Text style={styles.errorText}>{errors.position}</Text>

--- a/src/screens/profile/edit/ProfileFormStyle.ts
+++ b/src/screens/profile/edit/ProfileFormStyle.ts
@@ -59,7 +59,7 @@ export const styles = StyleSheet.create({
   levelOption: {
     flex: 1,
     paddingVertical: theme.spacing.spacing3,
-    paddingHorizontal: theme.spacing.spacing4,
+    paddingHorizontal: theme.spacing.spacing2,
     borderRadius: theme.spacing.spacing2,
     borderWidth: 1,
     borderColor: theme.colors.gray[300],
@@ -71,7 +71,7 @@ export const styles = StyleSheet.create({
     backgroundColor: theme.colors.grass[50],
   },
   levelOptionText: {
-    fontSize: theme.typography.fontSize.font4,
+    fontSize: theme.typography.fontSize.font3,
     color: theme.colors.text.sub,
     fontWeight: theme.typography.fontWeight.medium,
   },

--- a/src/screens/profile/edit/ProfileFormStyle.ts
+++ b/src/screens/profile/edit/ProfileFormStyle.ts
@@ -34,6 +34,10 @@ export const styles = StyleSheet.create({
   inputError: {
     borderColor: theme.colors.error,
   },
+  inputDisabled: {
+    backgroundColor: theme.colors.gray[100],
+    color: theme.colors.text.sub,
+  },
   textArea: {
     height: 100,
     textAlignVertical: 'top',

--- a/src/screens/profile/edit/edit_profile_screen.tsx
+++ b/src/screens/profile/edit/edit_profile_screen.tsx
@@ -1,3 +1,4 @@
+import { router } from 'expo-router';
 import React from 'react';
 import { ScrollView, Text, View, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -31,7 +32,12 @@ export default function EditProfileScreen() {
       }
 
       await updateProfileMutation.mutateAsync(cleanData);
-      Alert.alert('성공', '프로필이 수정되었습니다.');
+      Alert.alert('성공', '프로필이 수정되었습니다.', [
+        {
+          text: '확인',
+          onPress: () => router.back(),
+        },
+      ]);
       refetch();
     } catch (error) {
       console.error('프로필 수정 실패:', error);

--- a/src/screens/profile/profile_screen.tsx
+++ b/src/screens/profile/profile_screen.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useState } from 'react';
 import { ScrollView, Text, View, ActivityIndicator } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -12,23 +11,15 @@ import { theme } from '@/src/theme';
 import ProfileHeader from './components/profileHeader';
 import SettingCard from './components/settingTab/setting_card';
 import { defaultSettingsItems } from './components/settingTab/setting_items';
-import TabBar from './components/TabBar';
 import styles from './profile_style';
 
 function ProfileScreen() {
-  const [activeTab, setActiveTab] = useState<'reputation' | 'settings'>(
-    'settings'
-  );
   const insets = useSafeAreaInsets();
   const { token } = useAuth();
 
   const { data: userInfo, isLoading, error, refetch } = useUserProfile();
 
   const displayUser = userInfo;
-  const handleChangeTab = useCallback(
-    (t: 'reputation' | 'settings') => setActiveTab(t),
-    []
-  );
 
   if (!token) {
     return (
@@ -72,11 +63,8 @@ function ProfileScreen() {
           <Card style={styles.profileCard}>
             <ProfileHeader user={displayUser} />
           </Card>
-          <TabBar active={activeTab} onChange={handleChangeTab} />
 
-          {activeTab === 'settings' && (
-            <SettingCard items={defaultSettingsItems} />
-          )}
+          <SettingCard items={defaultSettingsItems} />
 
           <View style={styles.bottomSpacer} />
         </View>

--- a/src/screens/profile/profile_screen.tsx
+++ b/src/screens/profile/profile_screen.tsx
@@ -10,16 +10,17 @@ import { theme } from '@/src/theme';
 
 import ProfileHeader from './components/profileHeader';
 import SettingCard from './components/settingTab/setting_card';
-import { defaultSettingsItems } from './components/settingTab/setting_items';
+import { getDefaultSettingsItems } from './components/settingTab/setting_items';
 import styles from './profile_style';
 
 function ProfileScreen() {
   const insets = useSafeAreaInsets();
-  const { token } = useAuth();
+  const { token, logout } = useAuth();
 
   const { data: userInfo, isLoading, error, refetch } = useUserProfile();
 
   const displayUser = userInfo;
+  const settingsItems = getDefaultSettingsItems(logout);
 
   if (!token) {
     return (
@@ -64,7 +65,7 @@ function ProfileScreen() {
             <ProfileHeader user={displayUser} />
           </Card>
 
-          <SettingCard items={defaultSettingsItems} />
+          <SettingCard items={settingsItems} />
 
           <View style={styles.bottomSpacer} />
         </View>

--- a/src/screens/profile/profile_style.ts
+++ b/src/screens/profile/profile_style.ts
@@ -55,11 +55,16 @@ export default StyleSheet.create({
   profileInfo: {
     flex: 1,
   },
+  nameContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: theme.spacing.spacing2,
+    gap: theme.spacing.spacing3,
+  },
   profileName: {
     fontSize: 20,
     fontWeight: '600',
     color: theme.colors.text.main,
-    marginBottom: theme.spacing.spacing2,
   },
   profileUniversity: {
     fontSize: 16,


### PR DESCRIPTION
# PR 설명

## 주요 변경사항

### 프로필 화면 리팩토링
- 평판정보 탭 제거, 설정만 표시
- TabBar 컴포넌트 및 reputationTab 폴더 삭제
- 프로필 수정: 이름 필드 비활성화, 포지션 드롭다운 적용
- 저장 성공 시 프로필 화면으로 자동 이동

### 실력 배지 시스템 구현
- PRO → 금색, SEMI_PRO → 은색, AMATEUR → 동색 배지
- 이름 옆에 실력 배지 표시
- 둥근 모서리와 연한 배경색으로 가독성 개선
- Badge 컴포넌트에 gold/silver/bronze variant 추가

### 로그아웃 기능 구현
- 설정에서 로그아웃 버튼 클릭 시 확인 다이얼로그 표시
- AuthContext의 logout 함수와 연동
- 로그아웃 성공 시 토큰 제거 및 쿼리 클리어

### 코드 품질 개선
- ESLint/TypeScript/Prettier/Expo Doctor 통과
- 미사용 import 및 변수 정리
- 보안 취약점 0건
- 의존성 호환성 문제 해결

## 참고사항
- 평판정보 탭 관련 컴포넌트(TabBar, reputationTab) 삭제
- 프로필 화면에서 탭 네비게이션 제거, 설정 카드만 표시
- 실력 배지 시스템으로 사용자 실력 시각화
- 프로필 수정 시 이름은 수정 불가, 포지션은 드롭다운으로 선택
- 
이미지
<img width="300" height="600" alt="simulator_screenshot_39EFF3F7-758A-4625-A88B-9468536A1F7D" src="https://github.com/user-attachments/assets/29606c29-b5a7-445a-b300-7da2000b5e10" />

