### PR TITLE
팀 삭제, 수정 및 멤버 조회 구현

### DIFF
--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -9,6 +9,7 @@ import type {
   TeamListPageResponse,
   ApiTeamListPageResponse,
   TeamMember,
+  ApiTeamMember,
   TeamMemberPageResponse,
   ApiTeamMemberPageResponse,
   TeamMemberRole,
@@ -22,6 +23,7 @@ import {
   transformTeamListPageResponse,
   transformTeamDetailResponse,
   transformTeamMemberPageResponse,
+  transformTeamMemberItem,
   transformTeamJoinRequestPageResponse,
   getTeamTypeInEnglish,
   getSkillLevelInEnglish,
@@ -78,6 +80,16 @@ export const teamMemberApi = {
       TEAM_MEMBER_API.GET_MEMBERS(teamId, page, size)
     );
     return transformTeamMemberPageResponse(apiResponse);
+  },
+
+  getTeamMember: async (
+    teamId: string | number,
+    userId: string | number
+  ): Promise<TeamMember> => {
+    const apiResponse = await apiClient.get<ApiTeamMember>(
+      TEAM_MEMBER_API.GET_MEMBER(teamId, userId)
+    );
+    return transformTeamMemberItem(apiResponse);
   },
 
   updateMemberRole: (

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -109,16 +109,28 @@ export const joinTeamApi = {
 };
 
 export const teamEditApi = {
-  updateTeam: (
+  updateTeam: async (
     teamId: string | number,
     data: {
       name: string;
       description: string;
+      university: string;
       skillLevel: SkillLevel;
       teamType: TeamType;
     }
   ): Promise<TeamDetailResponse> => {
-    return apiClient.put<TeamDetailResponse>(TEAM_API.UPDATE(teamId), data);
+    const apiData = {
+      name: data.name,
+      description: data.description,
+      university: data.university,
+      skillLevel: getSkillLevelInEnglish(data.skillLevel),
+      teamType: getTeamTypeInEnglish(data.teamType),
+    };
+    const apiResponse = await apiClient.put<ApiTeamDetailResponse>(
+      TEAM_API.UPDATE(teamId),
+      apiData
+    );
+    return transformTeamDetailResponse(apiResponse);
   },
 };
 
@@ -146,5 +158,12 @@ export const teamJoinRequestApi = {
     return transformTeamJoinRequestPageResponse(apiResponse);
   },
 };
-export const deleteTeam = (teamId: string | number) =>
-  apiClient.delete(TEAM_API.DELETE(teamId));
+export const teamDeleteApi = {
+  deleteTeam: (
+    teamId: string | number
+  ): Promise<{ success: boolean; message: string }> => {
+    return apiClient.delete<{ success: boolean; message: string }>(
+      TEAM_API.DELETE(teamId)
+    );
+  },
+};

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -33,6 +33,8 @@ export const TEAM_API = {
 export const TEAM_MEMBER_API = {
   GET_MEMBERS: (teamId: string | number, page: number = 0, size: number = 10) =>
     `/api/teams/${teamId}/users?page=${page}&size=${size}`,
+  GET_MEMBER: (teamId: string | number, userId: string | number) =>
+    `/api/teams/${teamId}/users/${userId}`,
   UPDATE_ROLE: (teamId: string | number, userId: string | number) =>
     `/api/teams/${teamId}/users/${userId}`,
   REMOVE_MEMBER: (teamId: string | number, userId: string | number) =>

--- a/src/hooks/queries.ts
+++ b/src/hooks/queries.ts
@@ -21,6 +21,8 @@ import type {
   VerifyEmailRequest,
   UpdateProfileRequest,
   TeamMemberRole,
+  SkillLevel,
+  TeamType,
 } from '@/src/types';
 
 export const queries = {
@@ -383,6 +385,46 @@ export function useUpdateMemberRoleMutation() {
     },
     onError: (error: unknown) => {
       console.error('멤버 역할 수정 실패:', error);
+    },
+  });
+}
+
+export function useUpdateTeamMutation() {
+  return useMutation({
+    mutationFn: ({
+      teamId,
+      data,
+    }: {
+      teamId: string | number;
+      data: {
+        name: string;
+        description: string;
+        university: string;
+        skillLevel: SkillLevel;
+        teamType: TeamType;
+      };
+    }) => api.teamEditApi.updateTeam(teamId, data),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queries.team.key(variables.teamId),
+      });
+      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+    },
+    onError: (error: unknown) => {
+      console.error('팀 정보 수정 실패:', error);
+    },
+  });
+}
+
+export function useDeleteTeamMutation() {
+  return useMutation({
+    mutationFn: (teamId: string | number) =>
+      api.teamDeleteApi.deleteTeam(teamId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+    },
+    onError: (error: unknown) => {
+      console.error('팀 삭제 실패:', error);
     },
   });
 }

--- a/src/hooks/queries.ts
+++ b/src/hooks/queries.ts
@@ -74,6 +74,12 @@ export const queries = {
     fn: (teamId: string | number, page: number = 0, size: number = 10) =>
       api.teamMemberApi.getTeamMembers(teamId, page, size),
   },
+  teamMember: {
+    key: (teamId: string | number, userId: string | number) =>
+      ['teamMember', teamId, userId] as const,
+    fn: (teamId: string | number, userId: string | number) =>
+      api.teamMemberApi.getTeamMember(teamId, userId),
+  },
   teamJoinRequests: {
     key: (teamId: string | number) => ['teamJoinRequests', teamId] as const,
     fn: (teamId: string | number) =>
@@ -183,6 +189,17 @@ export function useTeamMembers(
     queryKey: queries.teamMembers.key(teamId, page, size),
     queryFn: () => queries.teamMembers.fn(teamId, page, size),
     enabled: !!teamId,
+  });
+}
+
+export function useTeamMember(
+  teamId: string | number,
+  userId: string | number
+) {
+  return useQuery({
+    queryKey: queries.teamMember.key(teamId, userId),
+    queryFn: () => queries.teamMember.fn(teamId, userId),
+    enabled: !!teamId && !!userId,
   });
 }
 

--- a/src/screens/team/management/components/modals/member_detail_modal.tsx
+++ b/src/screens/team/management/components/modals/member_detail_modal.tsx
@@ -1,0 +1,265 @@
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import {
+  View,
+  Text,
+  Modal,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+
+import { useTeamMember } from '@/src/hooks/queries';
+import { colors, spacing, typography } from '@/src/theme';
+import { formatDate } from '@/src/utils/date';
+import { getRoleDisplayName } from '@/src/utils/team';
+
+interface MemberDetailModalProps {
+  visible: boolean;
+  teamId: string | number;
+  userId: string | number;
+  onClose: () => void;
+}
+
+export default function MemberDetailModal({
+  visible,
+  teamId,
+  userId,
+  onClose,
+}: MemberDetailModalProps) {
+  const { data: member, isLoading, error } = useTeamMember(teamId, userId);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.modalContainer}>
+          <View style={styles.header}>
+            <Text style={styles.title}>팀원 정보</Text>
+            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+              <Ionicons name="close" size={24} color={colors.gray[600]} />
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.content}>
+            {isLoading ? (
+              <View style={styles.loadingContainer}>
+                <ActivityIndicator size="large" color={colors.grass[500]} />
+                <Text style={styles.loadingText}>
+                  팀원 정보를 불러오는 중...
+                </Text>
+              </View>
+            ) : error ? (
+              <View style={styles.errorContainer}>
+                <Ionicons
+                  name="alert-circle-outline"
+                  size={48}
+                  color={colors.red[500]}
+                />
+                <Text style={styles.errorText}>
+                  팀원 정보를 불러올 수 없습니다.
+                </Text>
+                <TouchableOpacity onPress={onClose} style={styles.retryButton}>
+                  <Text style={styles.retryButtonText}>확인</Text>
+                </TouchableOpacity>
+              </View>
+            ) : member ? (
+              <View style={styles.memberInfo}>
+                <View style={styles.avatarContainer}>
+                  <View style={styles.avatar}>
+                    <Ionicons
+                      name="person"
+                      size={40}
+                      color={colors.gray[400]}
+                    />
+                  </View>
+                  <View style={styles.roleBadge}>
+                    <Text style={styles.roleText}>
+                      {getRoleDisplayName(member.role)}
+                    </Text>
+                  </View>
+                </View>
+
+                <View style={styles.infoSection}>
+                  <View style={styles.infoItem}>
+                    <Ionicons
+                      name="person-outline"
+                      size={20}
+                      color={colors.gray[500]}
+                    />
+                    <View style={styles.infoContent}>
+                      <Text style={styles.infoLabel}>이름</Text>
+                      <Text style={styles.infoValue}>{member.name}</Text>
+                    </View>
+                  </View>
+
+                  <View style={styles.infoItem}>
+                    <Ionicons
+                      name="mail-outline"
+                      size={20}
+                      color={colors.gray[500]}
+                    />
+                    <View style={styles.infoContent}>
+                      <Text style={styles.infoLabel}>이메일</Text>
+                      <Text style={styles.infoValue}>{member.email}</Text>
+                    </View>
+                  </View>
+
+                  <View style={styles.infoItem}>
+                    <Ionicons
+                      name="football-outline"
+                      size={20}
+                      color={colors.gray[500]}
+                    />
+                    <View style={styles.infoContent}>
+                      <Text style={styles.infoLabel}>포지션</Text>
+                      <Text style={styles.infoValue}>{member.position}</Text>
+                    </View>
+                  </View>
+
+                  <View style={styles.infoItem}>
+                    <Ionicons
+                      name="calendar-outline"
+                      size={20}
+                      color={colors.gray[500]}
+                    />
+                    <View style={styles.infoContent}>
+                      <Text style={styles.infoLabel}>가입일</Text>
+                      <Text style={styles.infoValue}>
+                        {formatDate(member.joinedAt)}
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            ) : null}
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContainer: {
+    backgroundColor: colors.white,
+    borderRadius: spacing.spacing4,
+    width: '90%',
+    maxWidth: 400,
+    maxHeight: '80%',
+    shadowColor: colors.black,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 8,
+    elevation: 8,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: spacing.spacing5,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray[200],
+  },
+  title: {
+    fontSize: typography.fontSize.font5,
+    fontWeight: typography.fontWeight.bold,
+    color: colors.gray[900],
+  },
+  closeButton: {
+    padding: spacing.spacing1,
+  },
+  content: {
+    padding: spacing.spacing5,
+  },
+  loadingContainer: {
+    alignItems: 'center',
+    paddingVertical: spacing.spacing10,
+  },
+  loadingText: {
+    marginTop: spacing.spacing3,
+    fontSize: typography.fontSize.font4,
+    color: colors.gray[600],
+  },
+  errorContainer: {
+    alignItems: 'center',
+    paddingVertical: spacing.spacing10,
+  },
+  errorText: {
+    marginTop: spacing.spacing3,
+    fontSize: typography.fontSize.font4,
+    color: colors.red[500],
+    textAlign: 'center',
+  },
+  retryButton: {
+    marginTop: spacing.spacing4,
+    backgroundColor: colors.grass[500],
+    paddingHorizontal: spacing.spacing5,
+    paddingVertical: spacing.spacing3,
+    borderRadius: spacing.spacing3,
+  },
+  retryButtonText: {
+    color: colors.white,
+    fontSize: typography.fontSize.font4,
+    fontWeight: typography.fontWeight.medium,
+  },
+  memberInfo: {
+    alignItems: 'center',
+  },
+  avatarContainer: {
+    alignItems: 'center',
+    marginBottom: spacing.spacing6,
+  },
+  avatar: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: colors.gray[100],
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.spacing3,
+  },
+  roleBadge: {
+    backgroundColor: colors.grass[100],
+    paddingHorizontal: spacing.spacing3,
+    paddingVertical: spacing.spacing1,
+    borderRadius: spacing.spacing2,
+  },
+  roleText: {
+    fontSize: typography.fontSize.font3,
+    color: colors.grass[700],
+    fontWeight: typography.fontWeight.medium,
+  },
+  infoSection: {
+    width: '100%',
+    gap: spacing.spacing4,
+  },
+  infoItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.spacing3,
+  },
+  infoContent: {
+    flex: 1,
+  },
+  infoLabel: {
+    fontSize: typography.fontSize.font3,
+    color: colors.gray[500],
+    marginBottom: spacing.spacing1,
+  },
+  infoValue: {
+    fontSize: typography.fontSize.font4,
+    color: colors.gray[900],
+    fontWeight: typography.fontWeight.medium,
+  },
+});

--- a/src/screens/team/management/components/sections/member_list_section.tsx
+++ b/src/screens/team/management/components/sections/member_list_section.tsx
@@ -10,12 +10,14 @@ import { styles } from '../../styles/team_member_style';
 
 interface MemberListSectionProps {
   teamMembers: TeamMember[];
+  onMemberPress: (member: TeamMember) => void;
   onRoleChange: (member: TeamMember) => void;
   onRemoveMember: (member: TeamMember) => void;
 }
 
 export default memo(function MemberListSection({
   teamMembers,
+  onMemberPress,
   onRoleChange,
   onRemoveMember,
 }: MemberListSectionProps) {
@@ -41,7 +43,12 @@ export default memo(function MemberListSection({
 
       <View style={styles.memberList}>
         {teamMembers.map(member => (
-          <View key={member.id} style={styles.memberCard}>
+          <TouchableOpacity
+            key={member.id}
+            style={styles.memberCard}
+            onPress={() => onMemberPress(member)}
+            activeOpacity={0.7}
+          >
             <View style={styles.memberInfo}>
               <View style={styles.memberAvatar}>
                 <Ionicons name="person" size={20} color={theme.colors.white} />
@@ -101,7 +108,7 @@ export default memo(function MemberListSection({
                 </TouchableOpacity>
               </View>
             )}
-          </View>
+          </TouchableOpacity>
         ))}
 
         {teamMembers.length === 0 && (

--- a/src/screens/team/management/components/sections/team_members_section.tsx
+++ b/src/screens/team/management/components/sections/team_members_section.tsx
@@ -11,11 +11,13 @@ import { styles } from '../../styles/team_management_styles';
 interface TeamMembersSectionProps {
   teamMembers: TeamMember[] | undefined;
   membersLoading: boolean;
+  onMemberPress?: (member: TeamMember) => void;
 }
 
 export default memo(function TeamMembersSection({
   teamMembers,
   membersLoading,
+  onMemberPress,
 }: TeamMembersSectionProps) {
   const [showAllMembers, setShowAllMembers] = useState(false);
 
@@ -42,7 +44,12 @@ export default memo(function TeamMembersSection({
             ? teamMembers.slice(0, 6)
             : []
         ).map(member => (
-          <View key={member.id} style={styles.memberCard}>
+          <TouchableOpacity
+            key={member.id}
+            style={styles.memberCard}
+            onPress={() => onMemberPress?.(member)}
+            activeOpacity={0.7}
+          >
             <Ionicons
               name="shirt"
               size={24}
@@ -62,7 +69,7 @@ export default memo(function TeamMembersSection({
                 <Text style={styles.memberBadgeText}>👑</Text>
               </View>
             )}
-          </View>
+          </TouchableOpacity>
         ))}
 
         {(!Array.isArray(teamMembers) || teamMembers.length === 0) && (

--- a/src/screens/team/management/screens/team_management_screen.tsx
+++ b/src/screens/team/management/screens/team_management_screen.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, ScrollView, RefreshControl } from 'react-native';
 
 import { CustomHeader } from '@/src/components/ui/custom_header';
 import { useTeam, useTeamMembers, useUserProfile } from '@/src/hooks/queries';
+import type { TeamMember } from '@/src/types/team';
 
 import TeamInfoCard from '../components/cards/team_info_card';
+import MemberDetailModal from '../components/modals/member_detail_modal';
 import TeamMembersSection from '../components/sections/team_members_section';
 import EmptyState from '../components/states/empty_state';
 import LoadingState from '../components/states/loading_state';
@@ -17,6 +19,8 @@ interface TeamManagementScreenProps {
 export default function TeamManagementScreen({
   teamId,
 }: TeamManagementScreenProps) {
+  const [showMemberDetailModal, setShowMemberDetailModal] = useState(false);
+  const [selectedMember, setSelectedMember] = useState<TeamMember | null>(null);
   const { data: userProfile } = useUserProfile();
 
   const numericTeamId = teamId ? Number(teamId) : 0;
@@ -91,6 +95,11 @@ export default function TeamManagementScreen({
     );
   }
 
+  const handleMemberPress = (member: TeamMember) => {
+    setSelectedMember(member);
+    setShowMemberDetailModal(true);
+  };
+
   return (
     <View style={styles.container}>
       <CustomHeader title="팀 정보" />
@@ -112,9 +121,17 @@ export default function TeamManagementScreen({
           <TeamMembersSection
             teamMembers={teamMembers}
             membersLoading={membersLoading}
+            onMemberPress={handleMemberPress}
           />
         </View>
       </ScrollView>
+
+      <MemberDetailModal
+        visible={showMemberDetailModal}
+        teamId={numericTeamId}
+        userId={selectedMember?.userId || 0}
+        onClose={() => setShowMemberDetailModal(false)}
+      />
     </View>
   );
 }

--- a/src/screens/team/management/screens/team_member_screen.tsx
+++ b/src/screens/team/management/screens/team_member_screen.tsx
@@ -13,6 +13,7 @@ import type { TeamMember, TeamMemberRole } from '@/src/types/team';
 import { getRoleDisplayName } from '@/src/utils/team';
 
 import MemberInfoCard from '../components/cards/member_info_card';
+import MemberDetailModal from '../components/modals/member_detail_modal';
 import RoleChangeModal from '../components/modals/role_change_modal';
 import MemberListSection from '../components/sections/member_list_section';
 import { styles } from '../styles/team_member_style';
@@ -25,6 +26,7 @@ export default function MemberManagementScreen({
   teamId,
 }: MemberManagementScreenProps) {
   const [showRoleModal, setShowRoleModal] = useState(false);
+  const [showMemberDetailModal, setShowMemberDetailModal] = useState(false);
   const [selectedMember, setSelectedMember] = useState<TeamMember | null>(null);
 
   const numericTeamId = teamId ? Number(teamId) : 0;
@@ -83,6 +85,11 @@ export default function MemberManagementScreen({
       </View>
     );
   }
+
+  const handleMemberPress = (member: TeamMember) => {
+    setSelectedMember(member);
+    setShowMemberDetailModal(true);
+  };
 
   const handleRoleChange = (member: TeamMember) => {
     if (member.role === 'LEADER') {
@@ -196,11 +203,19 @@ export default function MemberManagementScreen({
           <MemberInfoCard />
           <MemberListSection
             teamMembers={teamMembers.content}
+            onMemberPress={handleMemberPress}
             onRoleChange={handleRoleChange}
             onRemoveMember={handleRemoveMember}
           />
         </View>
       </ScrollView>
+
+      <MemberDetailModal
+        visible={showMemberDetailModal}
+        teamId={numericTeamId}
+        userId={selectedMember?.userId || 0}
+        onClose={() => setShowMemberDetailModal(false)}
+      />
 
       <RoleChangeModal
         visible={showRoleModal}

--- a/src/screens/team/management/screens/team_settings_screen.tsx
+++ b/src/screens/team/management/screens/team_settings_screen.tsx
@@ -1,3 +1,4 @@
+import { router } from 'expo-router';
 import React, { useState } from 'react';
 import { View, Text, ScrollView, Alert } from 'react-native';
 
@@ -8,6 +9,7 @@ import {
   useTeamJoinWaitingList,
   useTeamMembers,
   useUserProfile,
+  useDeleteTeamMutation,
 } from '@/src/hooks/queries';
 import { colors } from '@/src/theme';
 
@@ -23,6 +25,7 @@ export default function TeamSettingsScreen({
 }: TeamSettingsScreenProps) {
   const [showJoinRequestsModal, setShowJoinRequestsModal] = useState(false);
   const { data: userProfile } = useUserProfile();
+  const deleteTeamMutation = useDeleteTeamMutation();
 
   const numericTeamId = teamId ? Number(teamId) : 0;
   const {
@@ -144,7 +147,25 @@ export default function TeamSettingsScreen({
           text: '삭제',
           style: 'destructive',
           onPress: () => {
-            Alert.alert('알림', '팀 삭제 기능은 아직 구현 중입니다.');
+            deleteTeamMutation.mutate(numericTeamId, {
+              onSuccess: () => {
+                Alert.alert('성공', '팀이 성공적으로 삭제되었습니다.', [
+                  {
+                    text: '확인',
+                    onPress: () => {
+                      router.push('/');
+                    },
+                  },
+                ]);
+              },
+              onError: error => {
+                console.error('팀 삭제 실패:', error);
+                Alert.alert(
+                  '오류',
+                  '팀 삭제에 실패했습니다. 다시 시도해주세요.'
+                );
+              },
+            });
           },
         },
       ]

--- a/src/utils/team.ts
+++ b/src/utils/team.ts
@@ -115,8 +115,8 @@ export const transformTeamMemberPageResponse = (
 // 팀 멤버 역할을 한글로 변환
 export const getRoleDisplayName = (role: TeamMemberRole): string => {
   const roleMapping: Record<TeamMemberRole, string> = {
-    LEADER: '팀장',
-    VICE_LEADER: '부팀장',
+    LEADER: '회장',
+    VICE_LEADER: '부회장',
     MEMBER: '팀원',
   };
   return roleMapping[role] || '팀원';


### PR DESCRIPTION
# PR 설명

## 개요
팀원 상세 정보 모달을 추가했습니다. 팀원 목록과 팀 정보 화면에서 팀원을 터치하면 상세 정보가 모달로 표시됩니다.

## 주요 변경사항

### API 레이어
- `teamMemberApi.getTeamMember` 추가
- `GET /api/teams/{teamId}/users/{userId}` 연동
- 응답을 프론트엔드 타입으로 변환

### 훅 레이어
- `teamMember` 쿼리 정의 추가
- `useTeamMember` 커스텀 훅 구현
- React Query로 캐싱 및 상태 관리

### UI 레이어
- `MemberDetailModal` 컴포넌트 생성
- 팀원 목록/팀 정보 화면에 터치 이벤트 추가
- 터치 시 상세 정보 모달 표시

### 리팩토링
- 역할 표시명 변경: "팀장" → "회장", "부팀장" → "부회장"

## 참고사항
- API 명세에 맞춰 `GET /api/teams/{teamId}/users/{userId}` 구현
- React Query로 데이터 캐싱 및 상태 관리
- 팀원 관리 화면과 팀 정보 화면에서 동일한 모달 사용
- 터치 피드백 및 로딩/에러 상태 처리 포함