### PR TITLE
refactor: match-waiting api 수정

### DIFF
--- a/app/match_application/index.tsx
+++ b/app/match_application/index.tsx
@@ -1,7 +1,12 @@
+import { useLocalSearchParams } from 'expo-router';
 import React from 'react';
 
 import MatchApplicationScreen from '@/src/screens/match_application/match_application_screen';
 
 export default function MatchApplicationRoute() {
-  return <MatchApplicationScreen />;
+  const { teamId } = useLocalSearchParams<{ teamId?: string }>();
+
+  return (
+    <MatchApplicationScreen teamId={teamId ? Number(teamId) : undefined} />
+  );
 }

--- a/src/api/match.ts
+++ b/src/api/match.ts
@@ -2,6 +2,7 @@ import {
   TEAM_MATCH_API,
   MATCH_CREATE_API,
   MATCH_REQUEST_API,
+  MATCH_WAITING_API,
 } from '@/src/constants/endpoints';
 import { apiClient } from '@/src/lib/api_client';
 import {
@@ -12,6 +13,8 @@ import {
   MatchRequestResponseDto,
   MatchConfirmedResponseDto,
   RecentMatchResponse,
+  MatchWaitingResponseDto,
+  MatchWaitingListRequestDto,
 } from '@/src/types/match';
 
 export const teamMatchApi = {
@@ -84,4 +87,40 @@ export async function rejectMatchRequestApi(
 ): Promise<MatchRequestResponseDto> {
   const url = MATCH_REQUEST_API.REJECT_REQUEST(requestId);
   return apiClient.patch<MatchRequestResponseDto>(url);
+}
+
+// 매치 대기 목록 조회 API (GET 방식, Query 파라미터)
+export async function getMatchWaitingList(
+  params: MatchWaitingListRequestDto
+): Promise<MatchWaitingResponseDto[]> {
+  const queryParams = new URLSearchParams();
+  queryParams.append('teamId', params.teamId.toString());
+  queryParams.append('selectDate', params.selectDate);
+  // 백엔드에서 startTime이 필수이므로 기본값 제공
+  queryParams.append('startTime', params.startTime || '00:00:00');
+
+  const url = `${MATCH_WAITING_API.GET_WAITING_LIST}?${queryParams.toString()}`;
+
+  interface PageResponse {
+    content: MatchWaitingResponseDto[];
+    empty: boolean;
+    first: boolean;
+    last: boolean;
+    number: number;
+    numberOfElements: number;
+    pageable: any;
+    size: number;
+    sort: any;
+  }
+
+  const response = await apiClient.get<PageResponse>(url);
+  return response.content || [];
+}
+
+// 매치 요청 취소 API
+export async function cancelMatchRequestApi(
+  requestId: number | string
+): Promise<MatchRequestResponseDto> {
+  const url = MATCH_REQUEST_API.CANCEL_REQUEST(requestId);
+  return apiClient.delete<MatchRequestResponseDto>(url);
 }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -79,6 +79,8 @@ export const MATCH_REQUEST_API = {
     `/api/matches/requests/${requestId}/accept`,
   REJECT_REQUEST: (requestId: string | number) =>
     `/api/matches/requests/${requestId}/reject`,
+  CANCEL_REQUEST: (requestId: string | number) =>
+    `/api/matches/requests/${requestId}`,
 };
 
 export const USER_JOIN_WAITING_API = {

--- a/src/hooks/useMatchWaitingList.ts
+++ b/src/hooks/useMatchWaitingList.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { MATCH_WAITING_API } from '@/src/constants/endpoints';
-import { apiClient } from '@/src/lib/api_client';
+import { getMatchWaitingList } from '@/src/api/match';
 import type {
   MatchWaitingListRequestDto,
   MatchWaitingResponseDto,
@@ -14,11 +13,7 @@ export const useMatchWaitingList = (
   return useQuery<MatchWaitingResponseDto[]>({
     queryKey: ['match-waiting-list', params],
     queryFn: async () => {
-      const res = await apiClient.post<{
-        content: MatchWaitingResponseDto[];
-      }>(MATCH_WAITING_API.GET_WAITING_LIST, params);
-
-      return res.content; // ✅ content 배열만 반환
+      return getMatchWaitingList(params);
     },
     ...options,
   });

--- a/src/screens/home/components/envelope_section/index.tsx
+++ b/src/screens/home/components/envelope_section/index.tsx
@@ -8,7 +8,11 @@ import { theme } from '@/src/theme';
 
 import styles from '../../home_style';
 
-export default memo(function EnvelopeSection() {
+interface EnvelopeSectionProps {
+  teamId?: number | null;
+}
+
+export default memo(function EnvelopeSection({ teamId }: EnvelopeSectionProps) {
   return (
     <>
       <View style={styles.envelopeSection}>
@@ -32,7 +36,18 @@ export default memo(function EnvelopeSection() {
       </View>
 
       <View style={styles.envelopeSection}>
-        <TouchableOpacity onPress={() => router.push(ROUTES.MATCH_APPLICATION)}>
+        <TouchableOpacity
+          onPress={() => {
+            if (teamId) {
+              router.push({
+                pathname: ROUTES.MATCH_APPLICATION,
+                params: { teamId: teamId.toString() },
+              });
+            } else {
+              router.push(ROUTES.MATCH_APPLICATION);
+            }
+          }}
+        >
           <View style={styles.envelopeHeader}>
             <View style={styles.envelopeIcon}>
               <Image

--- a/src/screens/home/home_screen.tsx
+++ b/src/screens/home/home_screen.tsx
@@ -58,7 +58,7 @@ export default function HomeScreen() {
         </View>
 
         <View style={styles.serviceSection}>
-          <EnvelopeSection />
+          <EnvelopeSection teamId={userProfile?.teamId || null} />
           <BenefitsSection teamId={userProfile?.teamId || null} />
         </View>
       </ScrollView>

--- a/src/screens/match_application/component/match_card.tsx
+++ b/src/screens/match_application/component/match_card.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 
+import { MatchWaitingResponseDto } from '@/src/types/match';
+
 type MatchCardProps = {
-  match: any; // 실제 타입으로 교체 필요
+  match: MatchWaitingResponseDto;
   onPressRequest?: () => void;
   disabled?: boolean;
 };
@@ -14,8 +16,37 @@ export default function MatchCard({
 }: MatchCardProps) {
   return (
     <View style={{ padding: 16, borderBottomWidth: 1, borderColor: '#ddd' }}>
-      <Text>{match?.location}</Text>
-      <Text>{match?.time}</Text>
+      <Text style={{ fontSize: 16, fontWeight: 'bold', marginBottom: 8 }}>
+        {match?.teamName?.name || '팀명 없음'}
+      </Text>
+
+      <Text style={{ marginBottom: 4 }}>📅 날짜: {match?.preferredDate}</Text>
+
+      <Text style={{ marginBottom: 4 }}>
+        ⏰ 시간: {match?.preferredTimeStart} - {match?.preferredTimeEnd}
+      </Text>
+
+      <Text style={{ marginBottom: 4 }}>
+        🏟️ 장소 ID: {match?.preferredVenueId}
+      </Text>
+
+      <Text style={{ marginBottom: 4 }}>
+        🎯 실력: {match?.skillLevelMin} ~ {match?.skillLevelMax}
+      </Text>
+
+      <Text style={{ marginBottom: 4 }}>
+        🎓 대학만: {match?.universityOnly ? '예' : '아니오'}
+      </Text>
+
+      {match?.message && (
+        <Text style={{ marginBottom: 4, fontStyle: 'italic' }}>
+          💬 메시지: {match.message}
+        </Text>
+      )}
+
+      <Text style={{ marginBottom: 8, color: '#666' }}>
+        상태: {match?.status} | 만료: {match?.expiresAt}
+      </Text>
 
       <TouchableOpacity
         onPress={onPressRequest}

--- a/src/screens/match_application/match_application_screen.tsx
+++ b/src/screens/match_application/match_application_screen.tsx
@@ -15,14 +15,20 @@ import type {
 import MatchCard from './component/match_card';
 import { styles } from './match_application_style';
 
-export default function MatchApplicationScreen() {
+interface MatchApplicationScreenProps {
+  teamId?: number;
+}
+
+export default function MatchApplicationScreen({
+  teamId,
+}: MatchApplicationScreenProps) {
   const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
   const [selectedTime, setSelectedTime] = useState<Date | null>(null);
 
   const { data: userProfile, refetch } = useUserProfile();
 
   const params: MatchWaitingListRequestDto = {
-    teamId: userProfile?.teamId ?? 0,
+    teamId: teamId ?? userProfile?.teamId ?? 0,
     selectDate: selectedDate
       ? selectedDate.toISOString().split('T')[0]
       : new Date().toISOString().split('T')[0],
@@ -33,11 +39,9 @@ export default function MatchApplicationScreen() {
 
   const { data, isLoading, error } = useMatchWaitingList(params);
 
-  // ✅ 매치 요청 훅
   const { mutate: requestMatch, isPending } = useMatchRequest();
 
   const handlePressRequest = async (waitingId: number) => {
-    // userProfile을 먼저 새로고침
     await refetch();
 
     const rawTeamId = userProfile?.teamId;
@@ -47,7 +51,6 @@ export default function MatchApplicationScreen() {
       return;
     }
 
-    // teamId를 number로 변환
     const numericTeamId = Number(rawTeamId);
 
     if (isNaN(numericTeamId) || numericTeamId <= 0) {
@@ -55,9 +58,7 @@ export default function MatchApplicationScreen() {
       return;
     }
 
-    // 메시지는 단순히 내 팀/내 유저 기준으로 생성
     const payload: MatchRequestRequestDto = {
-      requestTeamId: numericTeamId,
       requestMessage: `${userProfile.name}(${numericTeamId}) 팀이 매치 요청`,
     };
 
@@ -132,7 +133,7 @@ export default function MatchApplicationScreen() {
         renderItem={({ item }) => (
           <MatchCard
             match={item}
-            onPressRequest={() => handlePressRequest(item.waitingId)} // ✅ waitingId만 넘김
+            onPressRequest={() => handlePressRequest(item.waitingId)}
             disabled={isPending}
           />
         )}

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -44,7 +44,7 @@ export interface RecentMatchResponse {
 }
 
 export interface MatchWaitingListRequestDto {
-  teamId: number;
+  teamId: number; // 로그인한 사용자의 팀 ID (백엔드에서 필수)
   selectDate: string; // yyyy-MM-dd
   startTime?: string; // HH:mm:ss (없으면 필터 미적용)
 }
@@ -52,6 +52,9 @@ export interface MatchWaitingListRequestDto {
 export interface MatchWaitingResponseDto {
   waitingId: number;
   teamId: number;
+  teamName: {
+    name: string;
+  };
   preferredDate: string;
   preferredTimeStart: string;
   preferredTimeEnd: string;
@@ -83,7 +86,6 @@ export interface MatchCreateResponseDto {
   expiresAt: string;
 }
 export interface MatchRequestRequestDto {
-  requestTeamId: number;
   requestMessage: string;
 }
 


### PR DESCRIPTION
## **PR 설명**

### **참고사항**
- 매치 참여하기 화면에서 팀 ID 전달 로직 개선
- 매치 대기 목록 조회 API를 POST에서 GET으로 변경
- 매치 요청 취소 기능 추가
- 홈 화면에서 매치 참여하기로 팀 ID 전달

## **코드 개선**

### **주요 변경사항**

1. **매치 참여하기 화면 개선**
   - `app/match_application/index.tsx`: URL 파라미터로 `teamId` 전달
   - `src/screens/match_application/match_application_screen.tsx`: `teamId` prop 추가, 매치 요청 로직 정리

2. **매치 대기 목록 API 개선**
   - `src/hooks/useMatchWaitingList.ts`: API 호출을 `getMatchWaitingList`로 통합
   - `src/api/match.ts`: GET 방식으로 변경, 쿼리 파라미터 처리

3. **매치 요청 취소 기능 추가**
   - `src/constants/endpoints.ts`: `CANCEL_REQUEST` 엔드포인트 추가
   - `src/api/match.ts`: `cancelMatchRequestApi` 함수 추가

4. **홈 화면 개선**
   - `src/screens/home/home_screen.tsx`: `EnvelopeSection`에 `teamId` 전달
   - `src/screens/home/components/envelope_section/index.tsx`: 팀 ID 기반 라우팅

5. **매치 카드 UI 개선**
   - `src/screens/match_application/component/match_card.tsx`: 매치 정보 표시 개선, 타입 정의 추가


## **참고**
- 매치 대기 목록 조회는 GET으로 변경
- 홈 화면에서 매치 참여하기로 이동 시 팀 ID가 자동 전달
- 매치 요청 취소 기능 추가로 사용자 경험 개선