### PR TITLE
refactor: 팀 생성 대학교 입력 박스 수정

### DIFF
--- a/app/team/creation.tsx
+++ b/app/team/creation.tsx
@@ -1,7 +1,10 @@
+import { useLocalSearchParams } from 'expo-router';
 import React from 'react';
 
 import TeamCreationScreen from '@/src/screens/team/creation/team_creation_screen';
 
 export default function TeamCreationRoute() {
-  return <TeamCreationScreen />;
+  const { university } = useLocalSearchParams();
+
+  return <TeamCreationScreen initialUniversity={university as string} />;
 }

--- a/src/components/team/guide/buttons/index.tsx
+++ b/src/components/team/guide/buttons/index.tsx
@@ -3,12 +3,14 @@ import { useRouter } from 'expo-router';
 import { memo } from 'react';
 import { TouchableOpacity, Text, View } from 'react-native';
 
+import { useUserProfile } from '@/src/hooks/queries';
 import { colors } from '@/src/theme';
 
 import { styles } from '../buttons_styles';
 
 export default memo(function Buttons() {
   const router = useRouter();
+  const { data: userProfile } = useUserProfile();
 
   return (
     <View style={styles.buttonContainer}>
@@ -22,7 +24,12 @@ export default memo(function Buttons() {
 
       <TouchableOpacity
         style={styles.createButton}
-        onPress={() => router.push('/team/creation')}
+        onPress={() =>
+          router.push({
+            pathname: '/team/creation',
+            params: { university: userProfile?.university || '' },
+          })
+        }
       >
         <Ionicons
           name="add-circle-outline"

--- a/src/screens/team/creation/components/steps/team_basic_info.tsx
+++ b/src/screens/team/creation/components/steps/team_basic_info.tsx
@@ -1,15 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
-import React, { useState } from 'react';
-import {
-  View,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  Modal,
-  FlatList,
-} from 'react-native';
+import React from 'react';
+import { View, Text, TextInput, TouchableOpacity } from 'react-native';
 
-import { UNIVERSITIES } from '@/src/constants/universities';
 import { colors } from '@/src/theme';
 import { TeamType, TEAM_TYPES } from '@/src/types/team';
 
@@ -42,19 +34,12 @@ export default function TeamBasicInfo({
   onBack,
   errors,
 }: TeamBasicInfoProps) {
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-
   const isValid =
     teamName.trim().length > 0 &&
     teamName.length <= 100 &&
     university.trim().length > 0 &&
     university.length <= 100 &&
     teamType.length > 0;
-
-  const handleUniversitySelect = (selectedUniversity: string) => {
-    onUniversityChange(selectedUniversity);
-    setIsDropdownOpen(false);
-  };
 
   return (
     <View style={styles.stepContainer}>
@@ -80,23 +65,24 @@ export default function TeamBasicInfo({
 
         <View style={styles.inputContainer}>
           <Text style={styles.inputLabel}>대학교 *</Text>
-          <TouchableOpacity
+          <View
             style={[
               styles.dropdownButton,
+              styles.readOnlyField,
               errors.university && styles.textInputError,
             ]}
-            onPress={() => setIsDropdownOpen(true)}
           >
             <Text
               style={[
                 styles.dropdownButtonText,
+                styles.readOnlyText,
                 !university && styles.placeholderText,
               ]}
             >
-              {university || '대학교를 선택해주세요'}
+              {university || '대학교 정보를 불러오는 중...'}
             </Text>
-            <Ionicons name="chevron-down" size={20} color={colors.gray[600]} />
-          </TouchableOpacity>
+            <Ionicons name="lock-closed" size={20} color={colors.gray[400]} />
+          </View>
           {errors.university && (
             <Text style={styles.errorText}>{errors.university}</Text>
           )}
@@ -141,59 +127,6 @@ export default function TeamBasicInfo({
           <Ionicons name="arrow-forward" size={20} color={colors.white} />
         </TouchableOpacity>
       </View>
-
-      <Modal
-        visible={isDropdownOpen}
-        transparent={true}
-        animationType="fade"
-        onRequestClose={() => setIsDropdownOpen(false)}
-      >
-        <TouchableOpacity
-          style={styles.modalOverlay}
-          activeOpacity={1}
-          onPress={() => setIsDropdownOpen(false)}
-        >
-          <View style={styles.dropdownModal}>
-            <View style={styles.dropdownHeader}>
-              <Text style={styles.dropdownTitle}>대학교 선택</Text>
-              <TouchableOpacity onPress={() => setIsDropdownOpen(false)}>
-                <Ionicons name="close" size={24} color={colors.gray[600]} />
-              </TouchableOpacity>
-            </View>
-            <FlatList
-              data={UNIVERSITIES}
-              keyExtractor={item => item.id.toString()}
-              renderItem={({ item }) => (
-                <TouchableOpacity
-                  style={[
-                    styles.dropdownItem,
-                    university === item.name && styles.dropdownItemSelected,
-                  ]}
-                  onPress={() => handleUniversitySelect(item.name)}
-                >
-                  <Text
-                    style={[
-                      styles.dropdownItemText,
-                      university === item.name &&
-                        styles.dropdownItemTextSelected,
-                    ]}
-                  >
-                    {item.name}
-                  </Text>
-                  {university === item.name && (
-                    <Ionicons
-                      name="checkmark"
-                      size={20}
-                      color={colors.blue[500]}
-                    />
-                  )}
-                </TouchableOpacity>
-              )}
-              showsVerticalScrollIndicator={false}
-            />
-          </View>
-        </TouchableOpacity>
-      </Modal>
     </View>
   );
 }

--- a/src/screens/team/creation/team_creation_screen.tsx
+++ b/src/screens/team/creation/team_creation_screen.tsx
@@ -31,12 +31,18 @@ interface TeamFormData {
   description: string;
 }
 
-export default function TeamCreationScreen() {
+interface TeamCreationScreenProps {
+  initialUniversity?: string;
+}
+
+export default function TeamCreationScreen({
+  initialUniversity,
+}: TeamCreationScreenProps) {
   const router = useRouter();
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState<TeamFormData>({
     name: '',
-    university: '',
+    university: initialUniversity || '',
     teamType: DEFAULT_TEAM_TYPE,
     skillLevel: DEFAULT_SKILL_LEVEL,
     description: '',
@@ -122,9 +128,7 @@ export default function TeamCreationScreen() {
             university={formData.university}
             teamType={formData.teamType}
             onTeamNameChange={name => updateFormData('name', name)}
-            onUniversityChange={university =>
-              updateFormData('university', university)
-            }
+            onUniversityChange={() => {}} // 대학교는 수정 불가
             onTeamTypeChange={type => updateFormData('teamType', type)}
             {...stepProps}
             errors={{

--- a/src/screens/team/creation/team_creation_style.ts
+++ b/src/screens/team/creation/team_creation_style.ts
@@ -276,4 +276,11 @@ export const styles = StyleSheet.create({
     color: theme.colors.blue[500],
     fontWeight: theme.typography.fontWeight.medium,
   },
+  readOnlyField: {
+    backgroundColor: theme.colors.gray[50],
+    borderColor: theme.colors.gray[200],
+  },
+  readOnlyText: {
+    color: theme.colors.text.sub,
+  },
 });

--- a/src/screens/team/guide/components/buttons/index.tsx
+++ b/src/screens/team/guide/components/buttons/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'expo-router';
 import { memo, useState, useCallback } from 'react';
 import { TouchableOpacity, Text, View, Modal } from 'react-native';
 
+import { useUserProfile } from '@/src/hooks/queries';
 import { useMyJoinWaitingList } from '@/src/hooks/useTeamJoinRequest';
 import { colors } from '@/src/theme';
 
@@ -13,6 +14,7 @@ import JoinWaitingList from '../join_waiting_list';
 export default memo(function Buttons() {
   const router = useRouter();
   const [showJoinWaitingList, setShowJoinWaitingList] = useState(false);
+  const { data: userProfile } = useUserProfile();
 
   // 사용자의 팀 가입 신청 목록을 확인하여 신청이 있는지 체크
   const { data: joinWaitingData, refetch } = useMyJoinWaitingList(0, 1);
@@ -51,7 +53,12 @@ export default memo(function Buttons() {
 
       <TouchableOpacity
         style={styles.createButton}
-        onPress={() => router.push('/team/creation')}
+        onPress={() =>
+          router.push({
+            pathname: '/team/creation',
+            params: { university: userProfile?.university || '' },
+          })
+        }
       >
         <Ionicons
           name="add-circle-outline"


### PR DESCRIPTION
## **PR 설명**

### **참고사항**
- 회원가입 시 입력한 대학교와 팀 생성 시 선택하는 대학교가 달라지는 문제를 해결
- 사용자 경험 개선: 회원가입 정보와 일치하는 대학교가 자동으로 표시되도록 변경
- 드롭다운을 읽기 전용으로 변경하여 실수로 다른 대학교를 선택하는 것을 방지

### **코드 개선**
- **라우팅 파라미터 활용**: 팀 가이드 버튼에서 사용자의 대학교 정보를 라우팅 파라미터로 전달
- **Props 기반 데이터 전달**: API 호출 대신 props를 통해 대학교 정보를 효율적으로 전달
- **UI/UX 개선**: 잠금 아이콘과 회색 배경으로 읽기 전용 필드임을 명확히 표시
- **불필요한 기능 제거**: 사용하지 않는 Modal, FlatList, 드롭다운 관련 상태 및 핸들러 제거

### **참고**
- `useUserProfile` 훅을 활용하여 사용자 정보 조회
- `useLocalSearchParams`를 사용한 Expo Router 파라미터 받기

### **이미지**
<img width="300" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-10-03 at 00 28 08" src="https://github.com/user-attachments/assets/c9164501-4dab-480f-9106-7bc2dbfdb4f7" />