### PR TITLE
refactor: match request UI 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
     needs: quality-check
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
+      (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'develop'))
 
     steps:
       - name: 코드 체크아웃
@@ -75,11 +75,17 @@ jobs:
       - name: EAS Build 실행
         run: |
           if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            # iOS 추가 시: eas build --platform all --profile production --non-interactive
+            # 메인 브랜치: 프로덕션 빌드
             eas build --platform android --profile production --non-interactive
-          else
-            # iOS 추가 시: eas build --platform all --profile preview --non-interactive
+            echo "🚀 프로덕션 빌드 완료 (main 브랜치)"
+          elif [ "${{ github.ref }}" == "refs/heads/develop" ]; then
+            # 개발 브랜치: 프리뷰 빌드
             eas build --platform android --profile preview --non-interactive
+            echo "🔧 개발 빌드 완료 (develop 브랜치)"
+          else
+            # PR 머지: 프리뷰 빌드
+            eas build --platform android --profile preview --non-interactive
+            echo "📝 풀 리퀘스트 빌드 완료"
           fi
 
       - name: 빌드 후 작업 실행

--- a/app/match_application/index.tsx
+++ b/app/match_application/index.tsx
@@ -1,12 +1,15 @@
 import { useLocalSearchParams } from 'expo-router';
 import React from 'react';
 
+import { TeamGuard } from '@/src/components/auth/team_guard';
 import MatchApplicationScreen from '@/src/screens/match_application/match_application_screen';
 
 export default function MatchApplicationRoute() {
   const { teamId } = useLocalSearchParams<{ teamId?: string }>();
 
   return (
-    <MatchApplicationScreen teamId={teamId ? Number(teamId) : undefined} />
+    <TeamGuard fallbackMessage="매치에 참여하려면 먼저 팀에 가입해야 합니다.">
+      <MatchApplicationScreen teamId={teamId ? Number(teamId) : undefined} />
+    </TeamGuard>
   );
 }

--- a/app/match_making/match_info.tsx
+++ b/app/match_making/match_info.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
+import { TeamGuard } from '@/src/components/auth/team_guard';
 import MatchInfoScreen from '@/src/screens/match_making/match_info/match_info_screen';
 
 export default function MatchInfoRoute() {
-  return <MatchInfoScreen />;
+  return (
+    <TeamGuard fallbackMessage="매치를 생성하려면 먼저 팀에 가입해야 합니다.">
+      <MatchInfoScreen />
+    </TeamGuard>
+  );
 }

--- a/src/components/auth/team_guard.tsx
+++ b/src/components/auth/team_guard.tsx
@@ -1,0 +1,113 @@
+import { useRouter } from 'expo-router';
+import React, { useEffect } from 'react';
+import { View, Text, TouchableOpacity, Alert } from 'react-native';
+
+import { ROUTES } from '@/src/constants/routes';
+import { useUserProfile } from '@/src/hooks/queries';
+
+interface TeamGuardProps {
+  children: React.ReactNode;
+  fallbackMessage?: string;
+}
+
+export function TeamGuard({ children, fallbackMessage }: TeamGuardProps) {
+  const router = useRouter();
+  const { data: userProfile, isLoading } = useUserProfile();
+
+  useEffect(() => {
+    if (!isLoading && (!userProfile?.teamId || userProfile.teamId === null)) {
+      Alert.alert(
+        '팀 참여 필요',
+        fallbackMessage || '이 기능을 사용하려면 먼저 팀에 가입해야 합니다.',
+        [
+          {
+            text: '팀 만들기',
+            onPress: () => router.push(ROUTES.TEAM_CREATION),
+          },
+          {
+            text: '팀 참여하기',
+            onPress: () => router.push(ROUTES.TEAM_GUIDE),
+          },
+          {
+            text: '취소',
+            style: 'cancel',
+            onPress: () => router.back(),
+          },
+        ]
+      );
+    }
+  }, [userProfile?.teamId, isLoading, router, fallbackMessage]);
+
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text>로딩 중...</Text>
+      </View>
+    );
+  }
+
+  if (!userProfile?.teamId || userProfile.teamId === null) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
+          padding: 20,
+        }}
+      >
+        <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 16 }}>
+          팀 참여가 필요합니다
+        </Text>
+        <Text style={{ textAlign: 'center', marginBottom: 30, color: '#666' }}>
+          매치에 참여하려면 먼저 팀에 가입해야 합니다.
+        </Text>
+
+        <View style={{ gap: 12 }}>
+          <TouchableOpacity
+            style={{
+              backgroundColor: '#4CAF50',
+              paddingHorizontal: 24,
+              paddingVertical: 12,
+              borderRadius: 8,
+            }}
+            onPress={() => router.push(ROUTES.TEAM_CREATION)}
+          >
+            <Text style={{ color: 'white', textAlign: 'center' }}>
+              팀 만들기
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={{
+              backgroundColor: '#374151',
+              paddingHorizontal: 24,
+              paddingVertical: 12,
+              borderRadius: 8,
+            }}
+            onPress={() => router.push(ROUTES.TEAM_GUIDE)}
+          >
+            <Text style={{ color: 'white', textAlign: 'center' }}>
+              팀 참여하기
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            onPress={() => router.back()}
+            style={{
+              paddingHorizontal: 24,
+              paddingVertical: 12,
+              borderRadius: 8,
+              borderWidth: 1,
+              borderColor: '#ddd',
+            }}
+          >
+            <Text style={{ textAlign: 'center' }}>이전 페이지로</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/screens/home/components/envelope_section/index.tsx
+++ b/src/screens/home/components/envelope_section/index.tsx
@@ -47,7 +47,7 @@ export default memo(function EnvelopeSection({ teamId }: EnvelopeSectionProps) {
     if (!checkTeamMembership()) return;
     router.push({
       pathname: ROUTES.MATCH_APPLICATION,
-      params: { teamId: teamId.toString() },
+      params: teamId ? { teamId: teamId.toString() } : undefined,
     });
   };
 

--- a/src/screens/home/components/envelope_section/index.tsx
+++ b/src/screens/home/components/envelope_section/index.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { memo } from 'react';
-import { Image, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, Image, Text, TouchableOpacity, View } from 'react-native';
 
 import { ROUTES } from '@/src/constants/routes';
 import { theme } from '@/src/theme';
@@ -13,10 +13,48 @@ interface EnvelopeSectionProps {
 }
 
 export default memo(function EnvelopeSection({ teamId }: EnvelopeSectionProps) {
+  const checkTeamMembership = () => {
+    if (!teamId || teamId === null || teamId === undefined) {
+      Alert.alert(
+        '팀 참여 필요',
+        '매치에 참여하려면 먼저 팀에 가입해야 합니다.',
+        [
+          {
+            text: '취소',
+            style: 'cancel',
+          },
+          {
+            text: '팀 만들기',
+            onPress: () => router.push(ROUTES.TEAM_CREATION),
+          },
+          {
+            text: '팀 참여하기',
+            onPress: () => router.push(ROUTES.TEAM_GUIDE),
+          },
+        ]
+      );
+      return false;
+    }
+    return true;
+  };
+
+  const handleMatchCreation = () => {
+    if (!checkTeamMembership()) return;
+    router.push(ROUTES.MATCH_MAKING);
+  };
+
+  const handleMatchParticipation = () => {
+    if (!checkTeamMembership()) return;
+    router.push({
+      pathname: ROUTES.MATCH_APPLICATION,
+      params: { teamId: teamId.toString() },
+    });
+  };
+
   return (
     <>
       <View style={styles.envelopeSection}>
-        <TouchableOpacity onPress={() => router.push(ROUTES.MATCH_MAKING)}>
+        <TouchableOpacity onPress={handleMatchCreation}>
           <View style={styles.envelopeHeader}>
             <View style={styles.envelopeIcon}>
               <Image
@@ -36,18 +74,7 @@ export default memo(function EnvelopeSection({ teamId }: EnvelopeSectionProps) {
       </View>
 
       <View style={styles.envelopeSection}>
-        <TouchableOpacity
-          onPress={() => {
-            if (teamId) {
-              router.push({
-                pathname: ROUTES.MATCH_APPLICATION,
-                params: { teamId: teamId.toString() },
-              });
-            } else {
-              router.push(ROUTES.MATCH_APPLICATION);
-            }
-          }}
-        >
+        <TouchableOpacity onPress={handleMatchParticipation}>
           <View style={styles.envelopeHeader}>
             <View style={styles.envelopeIcon}>
               <Image


### PR DESCRIPTION
## **PR 설명**

### **참고사항**
- 홈화면에서 로그인하지 않은 사용자가 무한 로딩에 빠지는 문제 발견
- API 에러 시 사용자에게 적절한 해결 방안을 제공하지 못하는 문제 존재
- develop 브랜치에 머지되어도 CI/CD가 실행되지 않는 설정 누락

## **코드 개선**

**핵심 수정사항**
- `AuthContext`와 `useAuth` 훅을 활용한 인증 상태별 렌더링 로직 개선
- 토큰이 없을 때는 기본 홈화면 표시, 인증된 사용자만 API 호출하도록 수정
- API 에러 시 "다시 시도"와 "로그아웃 후 로그인" 두 가지 옵션 제공

**에러 처리 강화**
- `global_error_fallback.tsx`: 카드 스타일 UI와 테마 색상 적용
- `match_application_screen.tsx`: 프로필 에러와 매치 데이터 에러 분리 처리
- `home_screen.tsx`: 토큰 상태에 따른 조건부 렌더링 구현

**CI/CD 파이프라인 확장**
- `.github/workflows/ci.yml`: develop 브랜치 트리거 조건 추가
- 브랜치별 빌드 프로필 구분 (main: production, develop: preview)
- 자세한 빌드 로그 메시지로 트래킹 개선

**TypeScript 안정성**
- `envelope_section.tsx`: `teamId` null 체크 추가
- 모든 타입 에러 해결 및 컴파일 검증 통과