### PR TITLE
feat: 토큰 없이 앱 접근 시 API 오류 방지를 위한 인증 가드 추가

### DIFF
--- a/src/lib/api_client.ts
+++ b/src/lib/api_client.ts
@@ -34,6 +34,11 @@ class ApiClient {
     endpoint: string,
     options: AxiosRequestConfig = {}
   ): Promise<T> {
+    if (!this.token && this.isAuthRequiredEndpoint(endpoint)) {
+      this.onTokenExpired?.();
+      throw new ApiError('Authentication required', 401);
+    }
+
     try {
       const response: AxiosResponse<T> = await axios({
         ...options,
@@ -68,6 +73,17 @@ class ApiClient {
       }
       throw error;
     }
+  }
+
+  private isAuthRequiredEndpoint(endpoint: string): boolean {
+    const authRequiredEndpoints = [
+      '/api/profiles',
+      '/api/teams',
+      '/api/matches',
+      '/recommendedMatch',
+    ];
+
+    return authRequiredEndpoints.some(path => endpoint.includes(path));
   }
 
   async get<T>(endpoint: string): Promise<T> {


### PR DESCRIPTION
## **PR 설명**

### **문제 상황**
앱에서 가끔 토큰이 없는 상태로 홈 화면에 진입하게 되어 useUserProfile() 등의 API 호출 시 401 에러가 발생하는 문제가 있었습니다. 이는 라우팅 가드가 있음에도 불구하고 발생할 수 있는 상황으로 API 레벨에서 추가적인 보안장치가 필요했습니다.

### **해결 방법**
API 클라이언트에서 중앙 집중적으로 토큰 검증을 수행하도록 개선했습니다. 단순히 컴포넌트마다 개별적으로 체크하는 것보다 더 안전하고 일관성 있는 접근법입니다.

### **주요 변경사항**

#### **코드 개선**
**src/lib/api_client.ts**에 인증 가드 로직 추가:

```typescript
// 토큰이 필요한 API 요청인데 토큰이 없는 경우 자동 로그아웃 처리
if (!this.token && this.isAuthRequiredEndpoint(endpoint)) {
  this.onTokenExpired?.();
  throw new ApiError('Authentication required', 401);
}
```

- `isAuthRequiredEndpoint()` 메서드로 보호가 필요한 엔드포인트 정의
- 다음 엔드포인트들이 포함됨:
  - `/api/profiles`
  - `/api/teams` 
  - `/api/matches`
  - `/recommendedMatch`

### **선택 이유**

#### **1. 중앙 집중적 처리 vs 개별 컴포넌트 체크**
개별 컴포넌트에서 useAuth를 사용해 isAuthenticated를 체크하는 방식 대신, API 클라이언트 레벨에서 처리하면:
- 개발자가 실수로 가드를 빼먹을 가능성 제거
- 모든 API 호출에서 일관된 보안 로직 적용
- 코드 중복 방지 및 유지보수성 향상

#### **2. 자동 로그아웃 처리**
토큰이 없는 상태에서 API 호출을 시도하면 단순히 렌더링을 멈추는 것이 아니라, 명시적으로 logout()을 실행하여:
- 안전하고 확실한 인증 상태 정리
- 쿼리 캐시까지 함께 클리어하여 깔끔한 상태 복원
- 사용자를 로그인 화면으로 자연스럽게 리디렉션

#### **3. API 레벨 검증의 장점**
네트워크 요청 시점에서 검증하므로:
- 토큰 상태가 실시간으로 변경되어도 즉시 감지 가능
- 실제 API 호출 전에 차단하여 불필요한 네트워크 요청 방지