### PR TITLE
feat: team member api 검증

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6109,9 +6109,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.228",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.228.tgz",
-      "integrity": "sha512-nxkiyuqAn4MJ1QbobwqJILiDtu/jk14hEAWaMiJmNPh1Z+jqoFlBFZjdXwLWGeVSeu9hGLg6+2G9yJaW8rBIFA==",
+      "version": "1.5.229",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.229.tgz",
+      "integrity": "sha512-cwhDcZKGcT/rEthLRJ9eBlMDkh1sorgsuk+6dpsehV0g9CABsIqBxU4rLRjG+d/U6pYU1s37A4lSKrVc5lSQYg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -134,6 +134,12 @@ export const joinTeamApi = {
     apiClient.post<JoinTeamResponse>(TEAM_API.JOIN_TEAM, { teamId }),
 };
 
+export const teamExitApi = {
+  exitTeam: (teamId: string | number): Promise<void> => {
+    return apiClient.delete<void>(TEAM_API.EXIT_TEAM(teamId));
+  },
+};
+
 export const teamEditApi = {
   updateTeam: async (
     teamId: string | number,
@@ -181,6 +187,7 @@ export const teamJoinRequestApi = {
     const apiResponse = await apiClient.get<ApiTeamJoinRequestPageResponse>(
       `${TEAM_API.GET_JOIN_WAITING_LIST(teamId)}?${params.toString()}`
     );
+
     return transformTeamJoinRequestPageResponse(apiResponse);
   },
 
@@ -234,7 +241,6 @@ export const teamDeleteApi = {
   },
 };
 
-// 사용자별 가입 신청 목록 조회 API
 export const userJoinWaitingApi = {
   getMyJoinWaitingList: async (
     page: number = 0,

--- a/src/components/team/cards/team_info_card.tsx
+++ b/src/components/team/cards/team_info_card.tsx
@@ -13,11 +13,15 @@ import type { TeamDetailResponse } from '@/src/types/team';
 interface TeamInfoCardProps {
   team: TeamDetailResponse;
   canManageTeam: boolean;
+  onExitTeam?: () => void;
+  isTeamLeader?: boolean;
 }
 
 export default memo(function TeamInfoCard({
   team,
   canManageTeam,
+  onExitTeam,
+  isTeamLeader = false,
 }: TeamInfoCardProps) {
   const handleTeamManagement = () => {
     router.push(getTeamManagementSettingsUrl(team.id.toString()));
@@ -35,14 +39,30 @@ export default memo(function TeamInfoCard({
             <Text style={styles.teamTitle}>{team.name}</Text>
             <Text style={styles.teamSubtitle}>{team.university}</Text>
           </View>
-          {canManageTeam && (
-            <TouchableOpacity
-              style={styles.settingsButton}
-              onPress={handleTeamManagement}
-            >
-              <Ionicons name="settings-outline" size={20} color="white" />
-            </TouchableOpacity>
-          )}
+          <View style={styles.headerButtonsContainer}>
+            {/* 팀장이 아닌 경우에만 팀 탈퇴 버튼 표시 */}
+            {onExitTeam && !isTeamLeader && (
+              <TouchableOpacity
+                style={styles.headerExitButton}
+                onPress={onExitTeam}
+              >
+                <Ionicons
+                  name="exit-outline"
+                  size={16}
+                  color={colors.orange[600]}
+                />
+                <Text style={styles.headerExitButtonText}>팀 나가기</Text>
+              </TouchableOpacity>
+            )}
+            {canManageTeam && (
+              <TouchableOpacity
+                style={styles.settingsButton}
+                onPress={handleTeamManagement}
+              >
+                <Ionicons name="settings-outline" size={20} color="white" />
+              </TouchableOpacity>
+            )}
+          </View>
         </View>
       </View>
 
@@ -145,9 +165,15 @@ const styles = StyleSheet.create({
   headerContent: {
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'space-between',
   },
   teamTitleContainer: {
     flex: 1,
+  },
+  headerButtonsContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
   },
   teamTitle: {
     fontSize: 24,
@@ -158,6 +184,20 @@ const styles = StyleSheet.create({
   teamSubtitle: {
     fontSize: 16,
     color: 'rgba(255, 255, 255, 0.8)',
+    fontWeight: '500',
+  },
+  headerExitButton: {
+    backgroundColor: 'rgba(255, 255, 255, 0.15)',
+    borderRadius: 12,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  headerExitButtonText: {
+    color: colors.orange[500],
+    fontSize: 11,
     fontWeight: '500',
   },
   settingsButton: {
@@ -221,7 +261,7 @@ const styles = StyleSheet.create({
   recentMatchesButton: {
     backgroundColor: colors.blue[500],
     borderRadius: 16,
-    marginTop: 16,
+    marginTop: 0,
     shadowColor: colors.blue[300],
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,

--- a/src/components/team/modals/join_requests_modal.tsx
+++ b/src/components/team/modals/join_requests_modal.tsx
@@ -63,10 +63,8 @@ export default function JoinRequestsModal({
                   <View style={styles.requestHeader}>
                     <View style={styles.applicantInfo}>
                       <Text style={styles.applicantName}>
-                        신청자 ID: {request.applicantId}
-                      </Text>
-                      <Text style={styles.applicantEmail}>
-                        신청 ID: {request.id}
+                        {request.applicantName ||
+                          `사용자 ${request.applicantId}`}
                       </Text>
                     </View>
                     <View style={styles.requestStatus}>
@@ -98,12 +96,6 @@ export default function JoinRequestsModal({
                   </View>
 
                   <View style={styles.requestDetails}>
-                    <View style={styles.requestDetailRow}>
-                      <Text style={styles.requestDetailLabel}>팀 ID:</Text>
-                      <Text style={styles.requestDetailValue}>
-                        {request.teamId}
-                      </Text>
-                    </View>
                     {request.decisionReason && (
                       <View style={styles.requestDetailRow}>
                         <Text style={styles.requestDetailLabel}>

--- a/src/components/team/sections/member_list_section.tsx
+++ b/src/components/team/sections/member_list_section.tsx
@@ -10,6 +10,7 @@ import { styles } from './member_list_section_styles';
 
 interface MemberListSectionProps {
   teamMembers: TeamMember[];
+  currentUserMember?: TeamMember | null;
   onMemberPress: (member: TeamMember) => void;
   onRoleChange: (member: TeamMember) => void;
   onRemoveMember: (member: TeamMember) => void;
@@ -17,6 +18,7 @@ interface MemberListSectionProps {
 
 export default memo(function MemberListSection({
   teamMembers,
+  currentUserMember,
   onMemberPress,
   onRoleChange,
   onRemoveMember,
@@ -78,36 +80,40 @@ export default memo(function MemberListSection({
               </View>
             </View>
 
-            {member.role !== 'LEADER' && (
-              <View style={styles.memberActions}>
-                <TouchableOpacity
-                  style={styles.actionButton}
-                  onPress={() => onRoleChange(member)}
-                >
-                  <Ionicons
-                    name="swap-horizontal-outline"
-                    size={18}
-                    color={theme.colors.blue[600]}
-                  />
-                  <Text style={styles.actionButtonText}>역할변경</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.actionButton, styles.removeButton]}
-                  onPress={() => onRemoveMember(member)}
-                >
-                  <Ionicons
-                    name="trash-outline"
-                    size={18}
-                    color={theme.colors.red[600]}
-                  />
-                  <Text
-                    style={[styles.actionButtonText, styles.removeButtonText]}
+            {member.role !== 'LEADER' &&
+              currentUserMember &&
+              (currentUserMember.role === 'LEADER' ||
+                (currentUserMember.role === 'VICE_LEADER' &&
+                  member.role === 'MEMBER')) && (
+                <View style={styles.memberActions}>
+                  <TouchableOpacity
+                    style={styles.actionButton}
+                    onPress={() => onRoleChange(member)}
                   >
-                    강퇴
-                  </Text>
-                </TouchableOpacity>
-              </View>
-            )}
+                    <Ionicons
+                      name="swap-horizontal-outline"
+                      size={18}
+                      color={theme.colors.blue[600]}
+                    />
+                    <Text style={styles.actionButtonText}>역할변경</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.actionButton, styles.removeButton]}
+                    onPress={() => onRemoveMember(member)}
+                  >
+                    <Ionicons
+                      name="trash-outline"
+                      size={18}
+                      color={theme.colors.red[600]}
+                    />
+                    <Text
+                      style={[styles.actionButtonText, styles.removeButtonText]}
+                    >
+                      강퇴
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              )}
           </TouchableOpacity>
         ))}
 

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -26,6 +26,7 @@ export const TEAM_API = {
   GET_UNIVERSITY_LIST: '/api/universities',
   GET_TEAMS_BY_UNIVERSITY: '/api/teams',
   JOIN_TEAM: '/api/teams/join',
+  EXIT_TEAM: (teamId: string | number) => `/api/teams/${teamId}/users/me`,
   GET_JOIN_REQUESTS: (teamId: string | number) =>
     `/api/teams/${teamId}/joinRequests`,
   GET_JOIN_WAITING_LIST: (teamId: string | number) =>

--- a/src/hooks/queries.ts
+++ b/src/hooks/queries.ts
@@ -4,8 +4,10 @@ import {
   keepPreviousData,
   useInfiniteQuery,
 } from '@tanstack/react-query';
+import { router } from 'expo-router';
 
 import * as api from '@/src/api';
+import { ROUTES } from '@/src/constants/routes';
 import { useAuth } from '@/src/contexts/auth_context';
 import { queryClient } from '@/src/lib/query_client';
 import type {
@@ -451,6 +453,21 @@ export function useDeleteTeamMutation() {
     },
     onError: (error: unknown) => {
       console.error('팀 삭제 실패:', error);
+    },
+  });
+}
+
+export function useTeamExitMutation() {
+  return useMutation({
+    mutationFn: (teamId: string | number) => api.teamExitApi.exitTeam(teamId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['team'] });
+      queryClient.invalidateQueries({ queryKey: ['teamMembers'] });
+      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+      router.replace(ROUTES.TEAM_GUIDE);
+    },
+    onError: (error: unknown) => {
+      console.error('팀 나가기 실패:', error);
     },
   });
 }

--- a/src/screens/home/components/home_header/index.tsx
+++ b/src/screens/home/components/home_header/index.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { memo } from 'react';
-import { Image, Text, TouchableOpacity, View } from 'react-native';
+import { Image, Text, TouchableOpacity, View, Alert } from 'react-native';
 
 import { useAuth } from '@/src/contexts/auth_context';
 import { theme } from '@/src/theme';
@@ -11,11 +11,23 @@ export default memo(function HomeHeader() {
   const { logout } = useAuth();
 
   const handleLogout = async () => {
-    try {
-      await logout();
-    } catch (error) {
-      console.error('로그아웃 중 오류 발생:', error);
-    }
+    Alert.alert('로그아웃', '정말 로그아웃하시겠습니까?', [
+      {
+        text: '취소',
+        style: 'cancel',
+      },
+      {
+        text: '로그아웃',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await logout();
+          } catch (error) {
+            console.error('로그아웃 중 오류 발생:', error);
+          }
+        },
+      },
+    ]);
   };
 
   return (

--- a/src/screens/home/home_screen.tsx
+++ b/src/screens/home/home_screen.tsx
@@ -1,9 +1,9 @@
 import { useFocusEffect } from '@react-navigation/native';
-import { useCallback } from 'react';
-import { ScrollView, View, ActivityIndicator } from 'react-native';
+import { useCallback, useEffect, useRef } from 'react';
+import { ScrollView, View, ActivityIndicator, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { useUserProfile } from '@/src/hooks/queries';
+import { useUserProfile, useLogout } from '@/src/hooks/queries';
 import { theme } from '@/src/theme';
 
 import BenefitsSection from './components/benefit_section';
@@ -15,13 +15,57 @@ import styles from './home_style';
 
 export default function HomeScreen() {
   const insets = useSafeAreaInsets();
-  const { data: userProfile, isLoading, refetch } = useUserProfile();
+  const { data: userProfile, isLoading, refetch, error } = useUserProfile();
+  const logoutMutation = useLogout();
+  const alertShownRef = useRef(false);
+
+  const handleLogoutAndRedirect = useCallback(async () => {
+    try {
+      await logoutMutation.mutateAsync();
+    } catch (error) {
+      console.error('로그아웃 처리 중 오류:', error);
+    }
+  }, [logoutMutation]);
+
+  const handleErrorAlert = useCallback(() => {
+    if (alertShownRef.current) {
+      return;
+    }
+
+    alertShownRef.current = true;
+
+    Alert.alert(
+      '인증 오류',
+      '로그인이 필요합니다. 다시 로그인해주세요.',
+      [
+        {
+          text: '로그인 하기',
+          onPress: () => {
+            alertShownRef.current = false; // Alert 해제 후 재호출 가능하도록
+            handleLogoutAndRedirect();
+          },
+        },
+      ],
+      {
+        cancelable: false,
+        onDismiss: () => {
+          alertShownRef.current = false; // Alert가 닫힐 때 상태 리셋
+        },
+      }
+    );
+  }, [handleLogoutAndRedirect]);
 
   useFocusEffect(
     useCallback(() => {
       refetch();
     }, [refetch])
   );
+
+  useEffect(() => {
+    if (error) {
+      handleErrorAlert();
+    }
+  }, [error, handleErrorAlert]);
 
   if (isLoading) {
     return (

--- a/src/screens/team/management/team_management_screen.tsx
+++ b/src/screens/team/management/team_management_screen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, ScrollView, RefreshControl } from 'react-native';
+import { View, ScrollView, RefreshControl, Alert } from 'react-native';
 
 import TeamInfoCard from '@/src/components/team/cards/team_info_card';
 import MemberDetailModal from '@/src/components/team/modals/member_detail_modal';
@@ -7,7 +7,12 @@ import TeamMembersSection from '@/src/components/team/sections/team_members_sect
 import EmptyState from '@/src/components/team/states/empty_state';
 import LoadingState from '@/src/components/team/states/loading_state';
 import { CustomHeader } from '@/src/components/ui/custom_header';
-import { useTeam, useTeamMembers, useUserProfile } from '@/src/hooks/queries';
+import {
+  useTeam,
+  useTeamMembers,
+  useUserProfile,
+  useTeamExitMutation,
+} from '@/src/hooks/queries';
 import type { TeamMember } from '@/src/types/team';
 
 import { styles } from './team_management_styles';
@@ -22,6 +27,7 @@ export default function TeamManagementScreen({
   const [showMemberDetailModal, setShowMemberDetailModal] = useState(false);
   const [selectedMember, setSelectedMember] = useState<TeamMember | null>(null);
   const { data: userProfile } = useUserProfile();
+  const exitTeamMutation = useTeamExitMutation();
 
   const numericTeamId = teamId ? Number(teamId) : 0;
   const { data: team, isLoading, error, refetch } = useTeam(numericTeamId);
@@ -100,6 +106,68 @@ export default function TeamManagementScreen({
     setShowMemberDetailModal(true);
   };
 
+  const handleExitTeam = () => {
+    const isTeamLeader = currentUserMember?.role === 'LEADER';
+
+    if (isTeamLeader) {
+      Alert.alert(
+        '팀장 탈퇴 불가',
+        '팀장은 팀에서 나갈 수 없습니다.\n팀을 해산하려면 팀 설정에서 팀 삭제 기능을 사용해주세요.',
+        [
+          {
+            text: '확인',
+            style: 'default',
+          },
+        ]
+      );
+      return;
+    }
+
+    Alert.alert(
+      '팀 나가기',
+      '정말로 이 팀에서 나가시겠습니까?\n\n팀에서 나가면 모든 팀 관련 권한이 제거됩니다.',
+      [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '나가기',
+          style: 'destructive',
+          onPress: () => {
+            exitTeamMutation.mutate(numericTeamId, {
+              onSuccess: () => {
+                Alert.alert('성공', '팀에서 성공적으로 나가졌습니다.');
+              },
+              onError: error => {
+                console.error('팀 나가기 실패:', error);
+                let errorMessage =
+                  '팀 나가기에 실패했습니다. 다시 시도해주세요.';
+
+                if (error && typeof error === 'object' && 'status' in error) {
+                  const apiError = error as {
+                    status: number;
+                    message?: string;
+                    data?: any;
+                  };
+
+                  if (apiError.status === 403) {
+                    errorMessage = '팀장은 팀에서 나갈 수 없습니다.';
+                  } else if (apiError.status === 404) {
+                    errorMessage = '팀을 찾을 수 없습니다.';
+                  } else if (apiError.status === 400) {
+                    errorMessage = '마지막 남은 팀원은 나갈 수 없습니다.';
+                  } else if (apiError.message) {
+                    errorMessage = apiError.message;
+                  }
+                }
+
+                Alert.alert('오류', errorMessage);
+              },
+            });
+          },
+        },
+      ]
+    );
+  };
+
   return (
     <View style={styles.container}>
       <CustomHeader title="팀 정보" />
@@ -117,7 +185,12 @@ export default function TeamManagementScreen({
         }
       >
         <View style={styles.contentContainer}>
-          <TeamInfoCard team={team} canManageTeam={canManageTeam} />
+          <TeamInfoCard
+            team={team}
+            canManageTeam={canManageTeam}
+            onExitTeam={handleExitTeam}
+            isTeamLeader={currentUserMember?.role === 'LEADER'}
+          />
           <TeamMembersSection
             teamMembers={teamMembers}
             membersLoading={membersLoading}

--- a/src/screens/team/management/team_settings_screen.tsx
+++ b/src/screens/team/management/team_settings_screen.tsx
@@ -108,34 +108,7 @@ export default function TeamSettingsScreen({
     );
   }
 
-  if (!canManageTeam) {
-    return (
-      <View style={styles.container}>
-        <CustomHeader title="팀 관리" />
-        <View style={styles.loadingContainer}>
-          <Text
-            style={{
-              textAlign: 'center',
-              color: colors.red[500],
-              fontSize: 16,
-              marginBottom: 8,
-            }}
-          >
-            접근 권한이 없습니다
-          </Text>
-          <Text
-            style={{
-              textAlign: 'center',
-              color: colors.gray[600],
-              fontSize: 14,
-            }}
-          >
-            팀 관리 기능은 회장과 부회장만 사용할 수 있습니다.
-          </Text>
-        </View>
-      </View>
-    );
-  }
+  // 권한 충분하지 않은 경우에도 일반 멤버는 팀 탈퇴 기능만 사용 가능하도록 허용
 
   if (!joinRequestsData) {
     return (
@@ -216,7 +189,7 @@ export default function TeamSettingsScreen({
   const handleDeleteTeam = () => {
     Alert.alert(
       '팀 삭제',
-      '정말로 팀을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.\n\n팀 가입 대기 목록이나 다른 연관 데이터가 있으면 먼저 정리해주세요.',
+      '정말로 팀을 삭제하시겠습니까?\n\n⚠️ 이 작업은 되돌릴 수 없습니다.\n\n팀 삭제 전에 확인사항:\n• 팀 가입 대기 목록 정리\n• 진행 중인 매치 요청 처리\n• 다른 팀원들의 팀 탈퇴\n\n이 모든 작업이 완료된 후 삭제가 가능합니다.',
       [
         { text: '취소', style: 'cancel' },
         {
@@ -247,7 +220,7 @@ export default function TeamSettingsScreen({
 
                   if (apiError.status === 500) {
                     errorMessage =
-                      '팀 삭제 중 데이터베이스 오류가 발생했습니다. 팀 가입 대기 목록이나 다른 연관 데이터를 먼저 정리해주세요.';
+                      '팀 삭제 중 데이터베이스 오류가 발생했습니다.\n\n다음 데이터들이 남아있어 팀을 삭제할 수 없습니다:\n• 팀 가입 대기 목록\n• 진행 중인 매치 요청\n• 팀 관련 업무 데이터\n\n팀에서 먼저 이러한 데이터들을 정리해주세요.';
                   } else if (apiError.status === 404) {
                     errorMessage = '팀을 찾을 수 없습니다.';
                   } else if (apiError.status === 403) {

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -27,8 +27,8 @@ export interface ApiTeamDetailResponse {
   name: string;
   description: string;
   university: string;
-  skillLevel: string; // API에서는 string으로 받음 (AMATEUR, SEMI_PRO, PRO)
-  teamType: string; // API에서는 string으로 받음 (CENTRAL_CLUB, DEPARTMENT_CLUB, OTHER)
+  skillLevel: string;
+  teamType: string;
   memberCount: number;
   createdAt: string;
 }
@@ -49,8 +49,8 @@ export interface ApiTeamListItem {
   name: string;
   description: string;
   university: string;
-  skillLevel: string; // API에서는 string으로 받음 (AMATEUR, SEMI_PRO, PRO)
-  teamType: string; // API에서는 string으로 받음 (CENTRAL_CLUB, DEPARTMENT_CLUB, OTHER)
+  skillLevel: string;
+  teamType: string;
   memberCount: number;
   captainName: string;
   captainId: number;
@@ -70,7 +70,6 @@ export interface TeamListItem {
   createdAt: string;
 }
 
-// Spring Data Page 포맷 응답 타입
 export interface Pageable {
   pageNumber: number;
   pageSize: number;
@@ -216,9 +215,10 @@ export interface JoinRequest {
 
 export interface ApiTeamJoinRequest {
   id: number;
+  applicantName: string;
   teamId: number;
   applicantId: number;
-  status: string; // "대기중" | "승인" | "거절" | "취소"
+  status: string;
   decisionReason: string | null;
   decidedBy: number | null;
   decidedAt: string | null;
@@ -226,6 +226,7 @@ export interface ApiTeamJoinRequest {
 
 export interface TeamJoinRequest {
   id: number;
+  applicantName: string;
   teamId: number;
   applicantId: number;
   status: 'PENDING' | 'APPROVED' | 'REJECTED' | 'CANCELED';
@@ -262,7 +263,6 @@ export interface TeamJoinRequestPageResponse {
   empty: boolean;
 }
 
-// 팀 가입 신청 관련 타입
 export interface JoinWaitingRequest {
   message?: string;
 }
@@ -277,28 +277,24 @@ export interface JoinWaitingResponse {
   decidedAt: string | null;
 }
 
-// 팀 가입 승인 요청 타입
 export interface JoinWaitingApproveRequest {
   role: '회장' | '부회장' | '일반멤버';
   decisionReason?: string;
 }
 
-// 팀 가입 거절 요청 타입
 export interface JoinWaitingRejectRequest {
   reason: string;
 }
 
-// 팀 가입 취소 요청 타입
 export interface JoinWaitingCancelRequest {
   decisionReason?: string;
 }
 
-// 사용자별 가입 신청 목록 조회 관련 타입
 export interface ApiUserJoinWaitingItem {
   id: number;
   teamId: number;
   applicantId: number;
-  status: string; // "대기중" | "승인" | "거절" | "취소"
+  status: string;
   decisionReason: string | null;
   decidedBy: number | null;
   decidedAt: string | null;

--- a/src/utils/team.ts
+++ b/src/utils/team.ts
@@ -122,6 +122,10 @@ export const JOIN_REQUEST_STATUS_MAPPING: Record<
   승인: 'APPROVED',
   거절: 'REJECTED',
   취소: 'CANCELED',
+  PENDING: 'PENDING',
+  APPROVED: 'APPROVED',
+  REJECTED: 'REJECTED',
+  CANCELED: 'CANCELED',
 };
 
 export const getJoinRequestStatusInEnglish = (
@@ -135,6 +139,7 @@ export const transformTeamJoinRequestItem = (
 ): TeamJoinRequest => {
   return {
     id: apiItem.id,
+    applicantName: apiItem.applicantName,
     teamId: apiItem.teamId,
     applicantId: apiItem.applicantId,
     status: getJoinRequestStatusInEnglish(apiItem.status),
@@ -167,7 +172,6 @@ export const getJoinRequestStatusDisplayName = (
   return statusMapping[status] || '대기중';
 };
 
-// 사용자별 가입 신청 목록 조회 관련 변환 함수들
 export const USER_JOIN_WAITING_STATUS_MAPPING: Record<
   string,
   UserJoinWaitingItem['status']


### PR DESCRIPTION
## **PR 설명**

## **코드 개선**

### **주요 기능 추가**
- **팀 가입 신청 시 신청자 이름 표시**: 기존에 ID만 표시되던 것을 API 명세에 맞춰 실제 사용자 이름으로 변경
- **팀 나가기 기능 구현**: 팀장을 제외한 멤버들이 팀에서 나갈 수 있는 기능 추가
- **권한 기반 액션 제어**: 회장/부회장만 팀원 역할변경/강퇴 가능하도록 권한 체크 강화

### **버그 수정 및 개선**
- **중복 Alert 방지**: 홈 화면에서 토큰 만료 시 여러 Alert가 중복 표시되는 문제 해결
- **UI/UX 개선**: 팀 정보 카드에 팀 나가기 버튼 추가, 모달 UI 친화적 개선
- **에러 처리 강화**: API 에러별 상세 메시지 처리 및 사용자 안내 개선

### **코드 구조 개선**
- **훅 통합**: useTeamExit 훅을 queries.ts로 통합하여 관련 기능들의 중앙집중 관리
- **타입 정의 업데이트**: ApiTeamJoinRequest와 TeamJoinRequest에 applicantName 필드 추가
- **불필요한 주석 제거**: 코드 가독성 향상을 위한 주석 정리