### PR TITLE
refactor: login error 해결

### DIFF
--- a/src/hooks/queries.ts
+++ b/src/hooks/queries.ts
@@ -266,7 +266,7 @@ export function useCreateTeamMutation() {
     mutationFn: (teamData: CreateTeamRequest): Promise<CreateTeamResponse> =>
       api.createTeam(teamData),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+      queryClient.invalidateQueries({ queryKey: queries.userProfile.key });
     },
     onError: (error: unknown) => {
       console.error('팀 생성 실패:', error);
@@ -279,13 +279,13 @@ export function useJoinTeamMutation() {
     mutationFn: (teamId: number): Promise<JoinTeamResponse> =>
       api.joinTeamApi.joinTeam(teamId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+      queryClient.invalidateQueries({ queryKey: queries.userProfile.key });
     },
     onError: (error: unknown) => {
       console.error('팀 참여 실패:', error);
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+      queryClient.invalidateQueries({ queryKey: queries.userProfile.key });
     },
   });
 }
@@ -308,9 +308,8 @@ export function useLoginMutation() {
     mutationFn: queries.login.fn,
     onSuccess: (data: LoginResponse) => {
       login(data.accessToken);
-
       queryClient.invalidateQueries({ queryKey: queries.login.key });
-      queryClient.invalidateQueries({ queryKey: ['user'] });
+      queryClient.invalidateQueries({ queryKey: queries.userProfile.key });
     },
   });
 }
@@ -322,11 +321,8 @@ export function useRegisterMutation() {
     mutationFn: queries.register.fn,
     onSuccess: (data: RegisterResponse) => {
       login(data.accessToken);
-
       queryClient.invalidateQueries({ queryKey: queries.login.key });
-      queryClient.invalidateQueries({
-        queryKey: [{ queryKey: queries.user.key }],
-      });
+      queryClient.invalidateQueries({ queryKey: queries.userProfile.key });
     },
     onError: (error: unknown) => {
       console.error('회원가입 실패:', error);
@@ -359,7 +355,7 @@ export function useUpdateProfileMutation() {
     mutationFn: (data: UpdateProfileRequest) =>
       api.profileApi.updateProfile(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+      queryClient.invalidateQueries({ queryKey: queries.userProfile.key });
     },
     onError: (error: unknown) => {
       console.error('프로필 수정 실패:', error);
@@ -371,7 +367,7 @@ export function useDeleteProfileMutation() {
   return useMutation({
     mutationFn: () => api.profileApi.deleteProfile(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+      queryClient.invalidateQueries({ queryKey: queries.userProfile.key });
     },
     onError: (error: unknown) => {
       console.error('계정 탈퇴 실패:', error);
@@ -436,7 +432,7 @@ export function useUpdateTeamMutation() {
       queryClient.invalidateQueries({
         queryKey: queries.team.key(variables.teamId),
       });
-      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+      queryClient.invalidateQueries({ queryKey: queries.userProfile.key });
     },
     onError: (error: unknown) => {
       console.error('팀 정보 수정 실패:', error);
@@ -449,7 +445,7 @@ export function useDeleteTeamMutation() {
     mutationFn: (teamId: string | number) =>
       api.teamDeleteApi.deleteTeam(teamId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+      queryClient.invalidateQueries({ queryKey: queries.userProfile.key });
     },
     onError: (error: unknown) => {
       console.error('팀 삭제 실패:', error);
@@ -463,7 +459,7 @@ export function useTeamExitMutation() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['team'] });
       queryClient.invalidateQueries({ queryKey: ['teamMembers'] });
-      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+      queryClient.invalidateQueries({ queryKey: queries.userProfile.key });
       router.replace(ROUTES.TEAM_GUIDE);
     },
     onError: (error: unknown) => {

--- a/src/hooks/useRegisterValidation.ts
+++ b/src/hooks/useRegisterValidation.ts
@@ -4,7 +4,7 @@ import type { RegisterFormData } from './useRegisterForm';
 
 const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const UNIVERSITY_EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.ac\.kr$/;
-const KAKAO_TALK_ID_REGEX = /^[a-zA-Z0-9._-]+$/;
+const KAKAO_TALK_ID_REGEX = /^[a-zA-Z0-9._-]{4,20}$/;
 const STUDENT_YEAR_REGEX = /^\d{2}$/;
 const VERIFICATION_CODE_REGEX = /^\d{6}$/;
 
@@ -145,7 +145,8 @@ const getPatternErrorMessage = (field: string): string => {
     email: '올바른 이메일 형식을 입력해주세요',
     universityEmail: '학교 이메일은 *.ac.kr 도메인으로 입력해주세요',
     password: '비밀번호는 특수문자를 포함한 8자 이상으로 입력해주세요',
-    kakaoTalkId: '카카오톡 아이디는 영문, 숫자, ., _, - 만 사용 가능합니다',
+    kakaoTalkId:
+      '카카오톡 아이디는 영문, 숫자, 특수문자(-, _, .)를 포함하여 4~20자이어야 합니다',
   };
   return messages[field] || '올바른 형식으로 입력해주세요';
 };
@@ -158,8 +159,6 @@ export const profileValidationRules: ValidationRules = {
   },
   kakaoTalkId: {
     required: true,
-    minLength: 4,
-    maxLength: 20,
     pattern: KAKAO_TALK_ID_REGEX,
     label: '카카오톡 아이디',
     patternMessage:

--- a/src/screens/auth/components/login/login_form.tsx
+++ b/src/screens/auth/components/login/login_form.tsx
@@ -15,11 +15,7 @@ import { useLoginMutation } from '@/src/hooks/queries';
 import { useLoginForm } from '@/src/hooks/useLoginForm';
 import { theme } from '@/src/theme';
 
-interface LoginFormProps {
-  onLoginSuccess?: () => void;
-}
-
-function LoginForm({ onLoginSuccess }: LoginFormProps) {
+function LoginForm() {
   const { formData, errors, updateField, validateForm } = useLoginForm();
   const loginMutation = useLoginMutation();
   const [showPassword, setShowPassword] = useState(false);
@@ -31,7 +27,6 @@ function LoginForm({ onLoginSuccess }: LoginFormProps) {
     setPasswordError('');
     try {
       await loginMutation.mutateAsync(formData);
-      onLoginSuccess?.();
     } catch (error: unknown) {
       const errorMessage = (error as Error).message || '로그인에 실패했습니다.';
 

--- a/src/screens/auth/register/profile_info.tsx
+++ b/src/screens/auth/register/profile_info.tsx
@@ -60,7 +60,7 @@ export function ProfileInfo({ data, onChange, handlePrev, handleNext }: Props) {
   const isFormValid = useMemo(() => {
     const nameValid = data.name && data.name.trim().length >= 2;
     const kakaotalkIdValid =
-      data.kakaoTalkId && data.kakaoTalkId.trim().length >= 4;
+      data.kakaoTalkId && /^[a-zA-Z0-9._-]{4,20}$/.test(data.kakaoTalkId);
     const studentYearValid =
       data.studentYear && /^\d{2}$/.test(data.studentYear);
     const departmentValid =

--- a/src/screens/auth/register/register_screen.tsx
+++ b/src/screens/auth/register/register_screen.tsx
@@ -35,8 +35,24 @@ export default function RegisterScreen() {
         throw new Error('회원가입 실패');
       }
       Alert.alert('성공', '회원가입이 완료되었습니다.');
-    } catch {
-      Alert.alert('회원가입 실패', '다시 시도해주세요.');
+    } catch (error: unknown) {
+      const errorMessage =
+        (error as Error).message || '회원가입에 실패했습니다.';
+
+      // 백엔드에서 보낸 구체적인 에러 메시지 표시
+      if (errorMessage.includes('아이디의 형식이 올바르지 않습니다')) {
+        Alert.alert(
+          '입력 오류',
+          '카카오톡 아이디 형식을 확인해주세요.\n영문, 숫자, 특수문자(-, _, .)를 포함하여 4~20자이어야 합니다.'
+        );
+      } else if (errorMessage.includes('이미 존재하는')) {
+        Alert.alert(
+          '입력 오류',
+          '이미 사용 중인 정보입니다. 다른 정보를 입력해주세요.'
+        );
+      } else {
+        Alert.alert('회원가입 실패', errorMessage);
+      }
     }
   };
 


### PR DESCRIPTION
## **PR 설명**

로그인/회원가입 플로우의 안정성과 사용자 경험을 개선하기 위한 포괄적인 수정사항입니다. 주요 문제점들을 해결

### **참고사항**

- 로그인 후 홈화면으로 이동하지 않는 문제 해결
- 회원가입 시 카카오톡 아이디 검증 오류 해결
- 백엔드와 프론트엔드 간 검증 규칙 불일치 해결
- ESLint 경고 및 코드 품질 개선

## **코드 개선**

### **인증 플로우 개선**
- `useLoginMutation`/`useRegisterMutation`에서 쿼리 키 정확성 개선
- `['user', 'profile']` 키로 통일하여 캐시 무효화 안정화
- 로그인 성공 후 자동 홈화면 전환 보장

### **회원가입 검증 강화**
- 카카오톡 아이디 정규식을 `^[a-zA-Z0-9._-]{4,20}$`로 수정
- 백엔드 검증 규칙과 완전히 일치하도록 개선
- 구체적인 에러 메시지로 사용자 안내 개선