### PR TITLE
Feat/jskim3936/check created match

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -29,6 +29,7 @@ function AppContent() {
         <Stack.Screen name="profile" />
         <Stack.Screen name="match_making/match_info" />
         <Stack.Screen name="match_application/index" />
+        <Stack.Screen name="check_created_matches/index" />
       </Stack>
       <StatusBar style="auto" />
     </ThemeProvider>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,6 +30,7 @@ function AppContent() {
         <Stack.Screen name="match_making/match_info" />
         <Stack.Screen name="match_application/index" />
         <Stack.Screen name="check_created_matches/index" />
+        <Stack.Screen name="check_applied_matches/index" />
       </Stack>
       <StatusBar style="auto" />
     </ThemeProvider>

--- a/app/check_applied_matches/index.tsx
+++ b/app/check_applied_matches/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { TeamGuard } from '@/src/components/auth/team_guard';
+import CheckAppliedMatchesScreen from '@/src/screens/check_applied_matches';
+
+export default function CheckAppliedMatchesRoute() {
+  return (
+    <TeamGuard fallbackMessage="신청한한 매치를 보려려면 먼저 팀에 가입해야 합니다.">
+      <CheckAppliedMatchesScreen />
+    </TeamGuard>
+  );
+}

--- a/app/check_created_matches/index.tsx
+++ b/app/check_created_matches/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { TeamGuard } from '@/src/components/auth/team_guard';
+import CheckCreatedMatchesScreen from '@/src/screens/check_created_matches';
+
+export default function CheckCreatedMatchesRoute() {
+  return (
+    <TeamGuard fallbackMessage="생성된 매치를 보려려면 먼저 팀에 가입해야 합니다.">
+      <CheckCreatedMatchesScreen />
+    </TeamGuard>
+  );
+}

--- a/src/api/match.ts
+++ b/src/api/match.ts
@@ -127,3 +127,24 @@ export async function cancelMatchRequestApi(
   const url = MATCH_REQUEST_API.CANCEL_REQUEST(requestId);
   return apiClient.delete<MatchRequestResponseDto>(url);
 }
+
+export async function getMyCreatedMatches(): Promise<
+  MatchWaitingResponseDto[]
+> {
+  try {
+    const response = await apiClient.get<{
+      content: MatchWaitingResponseDto[];
+      empty: boolean;
+      totalElements: number;
+      totalPages: number;
+      first: boolean;
+      last: boolean;
+    }>('/api/matches/waiting/me');
+
+    // content 배열만 리턴
+    return response.content || [];
+  } catch (error) {
+    console.error('❌ getMyCreatedMatches API 에러:', error);
+    throw error;
+  }
+}

--- a/src/api/match.ts
+++ b/src/api/match.ts
@@ -178,3 +178,16 @@ export async function getMyAppliedMatches(): Promise<
     throw error;
   }
 }
+
+export async function cancelMatchRequestById(
+  requestId: number | string
+): Promise<MatchRequestResponseDto> {
+  try {
+    const url = `${MATCH_REQUEST_API.CANCEL_REQUEST(requestId)}`;
+    const response = await apiClient.delete<MatchRequestResponseDto>(url);
+    return response;
+  } catch (error) {
+    console.error('❌ cancelMatchRequestById API 에러:', error);
+    throw error;
+  }
+}

--- a/src/api/match.ts
+++ b/src/api/match.ts
@@ -16,6 +16,7 @@ import {
   MatchWaitingResponseDto,
   MatchWaitingListRequestDto,
   MatchWaitingCancelResponseDto,
+  MatchWaitingHistoryResponseDto,
 } from '@/src/types/match';
 
 export const teamMatchApi = {
@@ -155,4 +156,25 @@ export async function cancelCreatedMatchApi(
 ): Promise<MatchWaitingCancelResponseDto> {
   const url = MATCH_WAITING_API.CANCEL_WAITING(waitingId);
   return apiClient.patch<MatchWaitingCancelResponseDto>(url);
+}
+
+export async function getMyAppliedMatches(): Promise<
+  MatchWaitingHistoryResponseDto[]
+> {
+  try {
+    const response = await apiClient.get<{
+      content: MatchWaitingHistoryResponseDto[];
+      empty: boolean;
+      totalElements: number;
+      totalPages: number;
+      first: boolean;
+      last: boolean;
+    }>(MATCH_REQUEST_API.GET_MY_APPLIED_MATCHES);
+
+    // content 배열만 리턴
+    return response.content || [];
+  } catch (error) {
+    console.error('❌ getMyAppliedMatches API 에러:', error);
+    throw error;
+  }
 }

--- a/src/api/match.ts
+++ b/src/api/match.ts
@@ -15,6 +15,7 @@ import {
   RecentMatchResponse,
   MatchWaitingResponseDto,
   MatchWaitingListRequestDto,
+  MatchWaitingCancelResponseDto,
 } from '@/src/types/match';
 
 export const teamMatchApi = {
@@ -147,4 +148,11 @@ export async function getMyCreatedMatches(): Promise<
     console.error('❌ getMyCreatedMatches API 에러:', error);
     throw error;
   }
+}
+
+export async function cancelCreatedMatchApi(
+  waitingId: number | string
+): Promise<MatchWaitingCancelResponseDto> {
+  const url = MATCH_WAITING_API.CANCEL_WAITING(waitingId);
+  return apiClient.patch<MatchWaitingCancelResponseDto>(url);
 }

--- a/src/components/ui/modal_date_picker.tsx
+++ b/src/components/ui/modal_date_picker.tsx
@@ -1,12 +1,11 @@
-import DateTimePicker from '@react-native-community/datetimepicker';
 import React, { useState, useEffect } from 'react';
 import {
   Modal,
-  Platform,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
+  ScrollView,
 } from 'react-native';
 
 import { theme } from '@/src/theme';
@@ -26,29 +25,57 @@ export const ModalDatePicker: React.FC<ModalDatePickerProps> = ({
   onClose,
   title = '날짜 선택',
 }) => {
-  const [internalDate, setInternalDate] = useState(value);
+  console.log('ModalDatePicker 렌더링됨, visible:', visible);
+  const currentYear = new Date().getFullYear();
+  const [selectedMonth, setSelectedMonth] = useState<number>(value.getMonth());
+  const [selectedDay, setSelectedDay] = useState<number>(value.getDate());
 
   useEffect(() => {
     if (visible) {
-      setInternalDate(value);
+      setSelectedMonth(value.getMonth());
+      setSelectedDay(value.getDate());
     }
   }, [visible, value]);
 
-  const handleDateChange = (event: any, selectedDate?: Date) => {
-    if (selectedDate) {
-      setInternalDate(selectedDate);
-    }
-  };
-
   const handleConfirm = () => {
-    onDateChange(internalDate);
+    const confirmed = new Date(
+      currentYear,
+      selectedMonth,
+      selectedDay,
+      12,
+      0,
+      0
+    );
+
+    onDateChange(confirmed);
     onClose();
   };
 
   const handleCancel = () => {
-    setInternalDate(value);
+    setSelectedMonth(value.getMonth());
+    setSelectedDay(value.getDate());
     onClose();
   };
+
+  // 해당 월의 일수 계산
+  const getDaysInMonth = (year: number, month: number) => {
+    return new Date(year, month, 0).getDate();
+  };
+
+  // 월 범위 (0-11) - JavaScript Date 객체와 일치
+  const months = Array.from({ length: 12 }, (_, i) => i);
+
+  // 일 범위 (해당 월의 일수에 따라 동적)
+  const daysInSelectedMonth = getDaysInMonth(currentYear, selectedMonth);
+  const days = Array.from({ length: daysInSelectedMonth }, (_, i) => i + 1);
+
+  // 월이 변경될 때 일이 유효하지 않으면 조정
+  useEffect(() => {
+    const daysInNewMonth = getDaysInMonth(currentYear, selectedMonth);
+    if (selectedDay > daysInNewMonth) {
+      setSelectedDay(daysInNewMonth);
+    }
+  }, [selectedMonth, selectedDay]);
 
   return (
     <Modal
@@ -78,34 +105,86 @@ export const ModalDatePicker: React.FC<ModalDatePickerProps> = ({
           </View>
 
           <View style={styles.pickerContainer}>
-            <DateTimePicker
-              value={internalDate}
-              mode="date"
-              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-              onChange={handleDateChange}
-              style={styles.picker}
-              locale="ko-KR"
-              textColor={theme.colors.text.main}
-            />
+            <View style={styles.pickerRow}>
+              <View style={styles.dateColumn}>
+                <Text style={styles.dateLabel}>월</Text>
+                <View style={styles.datePickerContainer}>
+                  <ScrollColumn
+                    values={months}
+                    selectedValue={selectedMonth}
+                    onSelect={setSelectedMonth}
+                    displayValue={value => value + 1} // 0-11을 1-12로 표시
+                  />
+                </View>
+              </View>
+              <View style={styles.dateColumnSpacer} />
+              <View style={styles.dateColumn}>
+                <Text style={styles.dateLabel}>일</Text>
+                <View style={styles.datePickerContainer}>
+                  <ScrollColumn
+                    values={days}
+                    selectedValue={selectedDay}
+                    onSelect={setSelectedDay}
+                  />
+                </View>
+              </View>
+            </View>
           </View>
 
-          {Platform.OS === 'ios' && (
-            <View style={styles.footer}>
-              <TouchableOpacity
-                onPress={handleConfirm}
-                style={styles.confirmButton}
-              >
-                <Text style={styles.confirmButtonText}>확인</Text>
-              </TouchableOpacity>
-            </View>
-          )}
+          <View style={styles.footer}>
+            <TouchableOpacity
+              onPress={handleConfirm}
+              style={styles.confirmButton}
+            >
+              <Text style={styles.confirmButtonText}>확인</Text>
+            </TouchableOpacity>
+          </View>
         </TouchableOpacity>
       </TouchableOpacity>
     </Modal>
   );
 };
 
+interface ScrollColumnProps {
+  values: number[];
+  selectedValue: number;
+  onSelect: (value: number) => void;
+  displayValue?: (value: number) => number; // 표시용 변환 함수
+}
+
+const ScrollColumn: React.FC<ScrollColumnProps> = ({
+  values,
+  selectedValue,
+  onSelect,
+  displayValue = value => value, // 기본값: 그대로 표시
+}) => {
+  return (
+    <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
+      {values.map(value => {
+        const isSelected = value === selectedValue;
+        return (
+          <TouchableOpacity
+            key={value}
+            onPress={() => onSelect(value)}
+            style={[styles.scrollItem, isSelected && styles.scrollItemSelected]}
+          >
+            <Text
+              style={[
+                styles.scrollItemText,
+                isSelected && styles.scrollItemTextSelected,
+              ]}
+            >
+              {displayValue(value)}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </ScrollView>
+  );
+};
+
 const styles = StyleSheet.create({
+  // Modal Layout
   overlay: {
     flex: 1,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
@@ -117,6 +196,8 @@ const styles = StyleSheet.create({
     borderTopRightRadius: theme.spacing.spacing4,
     paddingBottom: theme.spacing.spacing6,
   },
+
+  // Header Styles
   header: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -139,13 +220,58 @@ const styles = StyleSheet.create({
     fontSize: theme.typography.fontSize.font4,
     color: theme.colors.text.sub,
   },
+
+  // Picker Styles
   pickerContainer: {
     paddingHorizontal: theme.spacing.spacing5,
     paddingVertical: theme.spacing.spacing4,
   },
-  picker: {
-    height: Platform.OS === 'ios' ? 200 : 'auto',
+  pickerRow: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
   },
+  dateColumn: {
+    flex: 1,
+    marginRight: 8,
+  },
+  dateColumnSpacer: {
+    width: 8,
+  },
+  dateLabel: {
+    color: theme.colors.text.sub,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  datePickerContainer: {
+    borderWidth: 1,
+    borderColor: theme.colors.border.light,
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+
+  // ScrollView Styles
+  scrollView: {
+    maxHeight: 200,
+  },
+  scrollItem: {
+    paddingVertical: 12,
+    alignItems: 'center',
+    backgroundColor: 'transparent',
+  },
+  scrollItemSelected: {
+    backgroundColor: theme.colors.blue[50],
+  },
+  scrollItemText: {
+    color: theme.colors.text.main,
+    fontWeight: theme.typography.fontWeight.regular,
+    fontSize: theme.typography.fontSize.font4,
+  },
+  scrollItemTextSelected: {
+    color: theme.colors.blue[600],
+    fontWeight: theme.typography.fontWeight.semibold,
+  },
+
+  // Footer Styles
   footer: {
     paddingHorizontal: theme.spacing.spacing5,
     paddingTop: theme.spacing.spacing4,

--- a/src/components/ui/modal_date_picker.tsx
+++ b/src/components/ui/modal_date_picker.tsx
@@ -25,7 +25,6 @@ export const ModalDatePicker: React.FC<ModalDatePickerProps> = ({
   onClose,
   title = '날짜 선택',
 }) => {
-  console.log('ModalDatePicker 렌더링됨, visible:', visible);
   const currentYear = new Date().getFullYear();
   const [selectedMonth, setSelectedMonth] = useState<number>(value.getMonth());
   const [selectedDay, setSelectedDay] = useState<number>(value.getDate());

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -85,6 +85,7 @@ export const MATCH_REQUEST_API = {
     `/api/matches/requests/${requestId}/reject`,
   CANCEL_REQUEST: (requestId: string | number) =>
     `/api/matches/requests/${requestId}`,
+  GET_MY_APPLIED_MATCHES: '/api/matches/requests/me',
 };
 
 export const USER_JOIN_WAITING_API = {

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -68,6 +68,8 @@ export const MATCH_CREATE_API = {
 export const MATCH_WAITING_API = {
   GET_WAITING_LIST: '/api/matches/waiting',
   GET_MY_CREATED_MATCHES: '/api/matches/waiting/me',
+  CANCEL_WAITING: (waitingId: string | number) =>
+    `/api/matches/waiting/${waitingId}/cancel`,
 };
 
 export const VENUE_API = {

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -67,6 +67,7 @@ export const MATCH_CREATE_API = {
 
 export const MATCH_WAITING_API = {
   GET_WAITING_LIST: '/api/matches/waiting',
+  GET_MY_CREATED_MATCHES: '/api/matches/waiting/me',
 };
 
 export const VENUE_API = {

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -18,6 +18,7 @@ export const ROUTES = {
   MATCH_MAKING: '/match_making/match_info',
   MATCH_APPLICATION: '/match_application',
   CHECK_CREATED_MATCHES: '/check_created_matches',
+  CHECK_APPLIED_MATCHES: '/check_applied_matches',
 
   TOURNAMENT: '/tournament',
 } as const;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -17,6 +17,7 @@ export const ROUTES = {
 
   MATCH_MAKING: '/match_making/match_info',
   MATCH_APPLICATION: '/match_application',
+  CHECK_CREATED_MATCHES: '/check_created_matches',
 
   TOURNAMENT: '/tournament',
 } as const;

--- a/src/hooks/useCancelMatch.ts
+++ b/src/hooks/useCancelMatch.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { cancelCreatedMatchApi } from '@/src/api/match';
+import type { MatchWaitingCancelResponseDto } from '@/src/types/match';
+
+export const useCancelMatch = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    MatchWaitingCancelResponseDto,
+    Error,
+    number // waitingId
+  >({
+    mutationFn: (waitingId: number) => cancelCreatedMatchApi(waitingId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['my-created-matches'], // ✅ v5 호환 문법
+      });
+    },
+  });
+};

--- a/src/hooks/useCancelMatchRequest.ts
+++ b/src/hooks/useCancelMatchRequest.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { cancelMatchRequestById } from '@/src/api/match';
+import type { MatchRequestResponseDto } from '@/src/types/match';
+
+export const useCancelMatchRequest = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<MatchRequestResponseDto, Error, number | string>({
+    mutationFn: async (requestId: number | string) => {
+      return await cancelMatchRequestById(requestId);
+    },
+    onSuccess: () => {
+      // 요청 목록 다시 갱신
+      queryClient.invalidateQueries({ queryKey: ['my-applied-matches'] });
+    },
+  });
+};

--- a/src/hooks/useCreateMatch.ts
+++ b/src/hooks/useCreateMatch.ts
@@ -1,11 +1,20 @@
-import { useMutation } from '@tanstack/react-query';
+// src/hooks/useCreateMatch.ts
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { createMatch } from '@/src/api/match';
+import type {
+  MatchCreateRequestDto,
+  MatchCreateResponseDto,
+} from '@/src/types/match';
 
-import { MatchCreateRequestDto, MatchCreateResponseDto } from '../types';
+export const useCreateMatch = () => {
+  const queryClient = useQueryClient();
 
-export function useCreateMatch() {
   return useMutation<MatchCreateResponseDto, Error, MatchCreateRequestDto>({
     mutationFn: createMatch,
+    onSuccess: () => {
+      // ✅ 새로 생성된 매치가 바로 반영되도록 무효화
+      queryClient.invalidateQueries({ queryKey: ['my-created-matches'] });
+    },
   });
-}
+};

--- a/src/hooks/useCreateMatch.ts
+++ b/src/hooks/useCreateMatch.ts
@@ -1,4 +1,3 @@
-// src/hooks/useCreateMatch.ts
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { createMatch } from '@/src/api/match';

--- a/src/hooks/useMyAppliedMatches.ts
+++ b/src/hooks/useMyAppliedMatches.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getMyAppliedMatches } from '@/src/api/match';
+import type { MatchWaitingHistoryResponseDto } from '@/src/types/match';
+
+export const useMyAppliedMatches = (options?: any) => {
+  return useQuery<MatchWaitingHistoryResponseDto[]>({
+    queryKey: ['my-applied-matches'],
+    queryFn: async () => {
+      const result = await getMyAppliedMatches();
+      return result;
+    },
+    ...options,
+  });
+};

--- a/src/hooks/useMyCreatedMatches.ts
+++ b/src/hooks/useMyCreatedMatches.ts
@@ -1,10 +1,15 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 import { getMyCreatedMatches } from '@/src/api/match';
 import type { MatchWaitingResponseDto } from '@/src/types/match';
 
-export const useMyCreatedMatches = (options?: any) => {
-  return useQuery<MatchWaitingResponseDto[]>({
+export const useMyCreatedMatches = (
+  options?: UseQueryOptions<
+    MatchWaitingResponseDto[], // data type
+    Error // error type
+  >
+) => {
+  return useQuery<MatchWaitingResponseDto[], Error>({
     queryKey: ['my-created-matches'],
     queryFn: async () => {
       const result = await getMyCreatedMatches();

--- a/src/hooks/useMyCreatedMatches.ts
+++ b/src/hooks/useMyCreatedMatches.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getMyCreatedMatches } from '@/src/api/match';
+import type { MatchWaitingResponseDto } from '@/src/types/match';
+
+export const useMyCreatedMatches = (options?: any) => {
+  return useQuery<MatchWaitingResponseDto[]>({
+    queryKey: ['my-created-matches'],
+    queryFn: async () => {
+      const result = await getMyCreatedMatches();
+      return result;
+    },
+    ...options,
+  });
+};

--- a/src/screens/check_applied_matches/check_applied_matches_style.ts
+++ b/src/screens/check_applied_matches/check_applied_matches_style.ts
@@ -1,0 +1,30 @@
+import { StyleSheet } from 'react-native';
+
+import { theme } from '@/src/theme';
+
+export const checkAppliedMatchesStyles = StyleSheet.create({
+  footer: {
+    position: 'absolute',
+    bottom: 20,
+    left: 16,
+    right: 16,
+    alignItems: 'center',
+  },
+  cancelButton: {
+    backgroundColor: theme.colors.red[600],
+    paddingVertical: 14,
+    paddingHorizontal: 32,
+    borderRadius: 12,
+    width: '100%',
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  cancelText: {
+    color: theme.colors.white,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/src/screens/check_applied_matches/check_applied_matches_style.ts
+++ b/src/screens/check_applied_matches/check_applied_matches_style.ts
@@ -5,26 +5,26 @@ import { theme } from '@/src/theme';
 export const checkAppliedMatchesStyles = StyleSheet.create({
   footer: {
     position: 'absolute',
-    bottom: 20,
-    left: 16,
-    right: 16,
+    bottom: theme.spacing.spacing5, // 20
+    left: theme.spacing.spacing4, // 16
+    right: theme.spacing.spacing4,
     alignItems: 'center',
   },
   cancelButton: {
     backgroundColor: theme.colors.red[600],
-    paddingVertical: 14,
-    paddingHorizontal: 32,
+    paddingVertical: theme.spacing.spacing3, // 14
+    paddingHorizontal: theme.spacing.spacing8, // 32
     borderRadius: 12,
     width: '100%',
     alignItems: 'center',
-    shadowColor: '#000',
+    shadowColor: theme.colors.black,
     shadowOpacity: 0.2,
     shadowRadius: 4,
     elevation: 4,
   },
   cancelText: {
     color: theme.colors.white,
-    fontSize: 16,
-    fontWeight: '600',
+    fontSize: theme.typography.fontSize.font4, // 16
+    fontWeight: theme.typography.fontWeight.semibold, // 600
   },
 });

--- a/src/screens/check_applied_matches/components/applied_match_card.tsx
+++ b/src/screens/check_applied_matches/components/applied_match_card.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 
 import { theme } from '@/src/theme';
 import type { MatchWaitingHistoryResponseDto } from '@/src/types/match';
 
 interface AppliedMatchCardProps {
   match: MatchWaitingHistoryResponseDto;
+  onSelect?: (id: number) => void;
+  isSelected?: boolean;
 }
 
-export default function AppliedMatchCard({ match }: AppliedMatchCardProps) {
+export default function AppliedMatchCard({
+  match,
+  onSelect,
+  isSelected = false,
+}: AppliedMatchCardProps) {
   const getName = (nameField: string | { name: string }) => {
     if (!nameField) return '알 수 없음';
     if (typeof nameField === 'object') return nameField.name;
@@ -35,7 +41,14 @@ export default function AppliedMatchCard({ match }: AppliedMatchCardProps) {
   };
 
   return (
-    <View style={styles.card}>
+    <TouchableOpacity
+      activeOpacity={0.8}
+      onPress={() => onSelect?.(match.requestId)}
+      style={[
+        styles.card,
+        isSelected && { borderColor: theme.colors.blue[500], borderWidth: 2 },
+      ]}
+    >
       <View style={styles.header}>
         <Text style={styles.teamTitle}>{`${requestTeam} → ${targetTeam}`}</Text>
         <View
@@ -73,7 +86,7 @@ export default function AppliedMatchCard({ match }: AppliedMatchCardProps) {
           <Text style={styles.message}>{match.requestMessage}</Text>
         </View>
       </View>
-    </View>
+    </TouchableOpacity>
   );
 }
 

--- a/src/screens/check_applied_matches/components/applied_match_card.tsx
+++ b/src/screens/check_applied_matches/components/applied_match_card.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+import { theme } from '@/src/theme';
+import type { MatchWaitingHistoryResponseDto } from '@/src/types/match';
+
+interface AppliedMatchCardProps {
+  match: MatchWaitingHistoryResponseDto;
+}
+
+export default function AppliedMatchCard({ match }: AppliedMatchCardProps) {
+  const getName = (nameField: string | { name: string }) => {
+    if (!nameField) return '알 수 없음';
+    if (typeof nameField === 'object') return nameField.name;
+    return nameField;
+  };
+
+  const requestTeam = getName(match.requestTeamName);
+  const targetTeam = getName(match.targetTeamName);
+  const date = match.requestAt?.split('T')[0] || '';
+  const time = match.requestAt?.split('T')[1]?.slice(0, 5) || '';
+  const status = match.status || 'PENDING';
+
+  const getStatusColor = () => {
+    switch (status.toUpperCase()) {
+      case 'APPROVED':
+        return theme.colors.green[600];
+      case 'REJECTED':
+        return theme.colors.red[600];
+      case 'CANCELED':
+        return theme.colors.gray[600];
+      default:
+        return theme.colors.yellow[600];
+    }
+  };
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <Text style={styles.teamTitle}>{`${requestTeam} → ${targetTeam}`}</Text>
+        <View
+          style={[
+            styles.statusBadge,
+            {
+              borderColor: getStatusColor(),
+              backgroundColor: getStatusColor() + '20',
+            },
+          ]}
+        >
+          <Text style={[styles.statusText, { color: getStatusColor() }]}>
+            {status === 'PENDING'
+              ? '대기 중'
+              : status === 'APPROVED'
+                ? '수락됨'
+                : status === 'REJECTED'
+                  ? '거절됨'
+                  : '취소됨'}
+          </Text>
+        </View>
+      </View>
+
+      <View style={styles.body}>
+        <View style={styles.row}>
+          <Text style={styles.label}>요청 일자</Text>
+          <Text style={styles.value}>{date}</Text>
+        </View>
+        <View style={styles.row}>
+          <Text style={styles.label}>요청 시간</Text>
+          <Text style={styles.value}>{time}</Text>
+        </View>
+        <View style={[styles.row, { marginTop: 6 }]}>
+          <Text style={styles.label}>요청 메시지</Text>
+          <Text style={styles.message}>{match.requestMessage}</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: theme.colors.white,
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 4,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  teamTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: theme.colors.gray[900],
+  },
+  statusBadge: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  statusText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  body: {
+    marginTop: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginVertical: 2,
+  },
+  label: {
+    fontSize: 13,
+    color: theme.colors.gray[600],
+  },
+  value: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: theme.colors.gray[800],
+  },
+  message: {
+    marginTop: 4,
+    fontSize: 13,
+    color: theme.colors.gray[700],
+    lineHeight: 18,
+  },
+});

--- a/src/screens/check_applied_matches/index.tsx
+++ b/src/screens/check_applied_matches/index.tsx
@@ -1,12 +1,74 @@
-import { View, Text } from 'react-native';
+import React, { useState, useCallback } from 'react';
+import { View, Text, FlatList, ScrollView, RefreshControl } from 'react-native';
 
 import { CustomHeader } from '@/src/components/ui/custom_header';
+import { useUserProfile } from '@/src/hooks/queries';
+import { useMyAppliedMatches } from '@/src/hooks/useMyAppliedMatches';
+import AppliedMatchCard from '@/src/screens/check_applied_matches/components/applied_match_card';
+import { styles } from '@/src/screens/match_application/match_application_style';
 
 export default function CheckAppliedMatchesScreen() {
+  const [refreshing, setRefreshing] = useState(false);
+
+  const { refetch: refetchProfile } = useUserProfile();
+  const {
+    data: appliedMatches,
+    isLoading,
+    error,
+    refetch: refetchMatches,
+  } = useMyAppliedMatches();
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await Promise.all([refetchProfile(), refetchMatches()]);
+    setRefreshing(false);
+  }, [refetchProfile, refetchMatches]);
+
+  const renderMatchCard = ({ item }: { item: any }) => (
+    <AppliedMatchCard match={item} />
+  );
+
   return (
-    <View>
-      <Text>CheckAppliedMatches</Text>
+    <View style={styles.container}>
       <CustomHeader title="신청한 매치 보기" />
+
+      <ScrollView
+        style={styles.scrollContainer}
+        contentContainerStyle={styles.scrollContent}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            colors={['#007AFF']}
+            tintColor="#007AFF"
+          />
+        }
+      >
+        {isLoading ? (
+          <View style={styles.loadingState}>
+            <Text style={styles.loadingText}>매치를 불러오는 중...</Text>
+          </View>
+        ) : error ? (
+          <View style={styles.errorState}>
+            <Text style={styles.errorText}>데이터를 불러올 수 없습니다</Text>
+          </View>
+        ) : (
+          <FlatList
+            data={appliedMatches || []}
+            keyExtractor={(item, index) => String(item.requestId ?? index)}
+            renderItem={renderMatchCard}
+            ListEmptyComponent={
+              <View style={styles.emptyState}>
+                <Text style={styles.emptyStateText}>
+                  신청한 매치가 없습니다
+                </Text>
+              </View>
+            }
+            scrollEnabled={false}
+            showsVerticalScrollIndicator={false}
+          />
+        )}
+      </ScrollView>
     </View>
   );
 }

--- a/src/screens/check_applied_matches/index.tsx
+++ b/src/screens/check_applied_matches/index.tsx
@@ -1,14 +1,23 @@
 import React, { useState, useCallback } from 'react';
-import { View, Text, FlatList, ScrollView, RefreshControl } from 'react-native';
+import {
+  View,
+  Text,
+  FlatList,
+  ScrollView,
+  RefreshControl,
+  TouchableOpacity,
+} from 'react-native';
 
 import { CustomHeader } from '@/src/components/ui/custom_header';
 import { useUserProfile } from '@/src/hooks/queries';
 import { useMyAppliedMatches } from '@/src/hooks/useMyAppliedMatches';
+import { checkAppliedMatchesStyles } from '@/src/screens/check_applied_matches/check_applied_matches_style'; // ✅ 추가
 import AppliedMatchCard from '@/src/screens/check_applied_matches/components/applied_match_card';
 import { styles } from '@/src/screens/match_application/match_application_style';
 
 export default function CheckAppliedMatchesScreen() {
   const [refreshing, setRefreshing] = useState(false);
+  const [selectedMatchId, setSelectedMatchId] = useState<number | null>(null);
 
   const { refetch: refetchProfile } = useUserProfile();
   const {
@@ -22,19 +31,33 @@ export default function CheckAppliedMatchesScreen() {
     setRefreshing(true);
     await Promise.all([refetchProfile(), refetchMatches()]);
     setRefreshing(false);
+    setSelectedMatchId(null);
   }, [refetchProfile, refetchMatches]);
 
+  const handleSelect = (id: number) => {
+    setSelectedMatchId(prev => (prev === id ? null : id)); // 선택 토글
+  };
+
+  const handleCancel = () => {
+    console.log('🧨 취소 버튼 클릭 - requestId:', selectedMatchId);
+    // 이후 useCancelRequest 훅 연결 예정
+  };
+
   const renderMatchCard = ({ item }: { item: any }) => (
-    <AppliedMatchCard match={item} />
+    <AppliedMatchCard
+      match={item}
+      onSelect={handleSelect}
+      isSelected={selectedMatchId === item.requestId}
+    />
   );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { flex: 1 }]}>
       <CustomHeader title="신청한 매치 보기" />
 
       <ScrollView
-        style={styles.scrollContainer}
-        contentContainerStyle={styles.scrollContent}
+        style={[styles.scrollContainer, { flex: 1 }]}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: 100 }]} // 버튼 영역 확보
         refreshControl={
           <RefreshControl
             refreshing={refreshing}
@@ -69,6 +92,20 @@ export default function CheckAppliedMatchesScreen() {
           />
         )}
       </ScrollView>
+
+      {/* ✅ 선택된 매치 있을 때만 하단 버튼 표시 */}
+      {selectedMatchId && (
+        <View style={checkAppliedMatchesStyles.footer}>
+          <TouchableOpacity
+            style={checkAppliedMatchesStyles.cancelButton}
+            onPress={handleCancel}
+          >
+            <Text style={checkAppliedMatchesStyles.cancelText}>
+              매치 요청 취소하기
+            </Text>
+          </TouchableOpacity>
+        </View>
+      )}
     </View>
   );
 }

--- a/src/screens/check_applied_matches/index.tsx
+++ b/src/screens/check_applied_matches/index.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from 'react-native';
+
+import { CustomHeader } from '@/src/components/ui/custom_header';
+
+export default function CheckAppliedMatchesScreen() {
+  return (
+    <View>
+      <Text>CheckAppliedMatches</Text>
+      <CustomHeader title="신청한 매치 보기" />
+    </View>
+  );
+}

--- a/src/screens/check_created_matches/index.tsx
+++ b/src/screens/check_created_matches/index.tsx
@@ -1,9 +1,74 @@
-import { View, Text } from 'react-native';
+import React, { useState, useCallback } from 'react';
+import { View, Text, FlatList, ScrollView, RefreshControl } from 'react-native';
+
+import { CustomHeader } from '@/src/components/ui/custom_header';
+import { useUserProfile } from '@/src/hooks/queries';
+import { useMyCreatedMatches } from '@/src/hooks/useMyCreatedMatches';
+import MatchCard from '@/src/screens/match_application/components/match_card';
+import { styles } from '@/src/screens/match_application/match_application_style';
 
 export default function CheckCreatedMatchesScreen() {
+  const [refreshing, setRefreshing] = useState(false);
+
+  const { refetch: refetchProfile } = useUserProfile();
+  const {
+    data: createdMatches,
+    isLoading,
+    error,
+    refetch: refetchMatches,
+  } = useMyCreatedMatches();
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await Promise.all([refetchProfile(), refetchMatches()]);
+    setRefreshing(false);
+  }, [refetchProfile, refetchMatches]);
+
+  const renderMatchCard = ({ item }: { item: any }) => (
+    <MatchCard match={item} showStatus={true} isCancellable={true} />
+  );
+
   return (
-    <View>
-      <Text>CheckCreatedMatchesScreen</Text>
+    <View style={styles.container}>
+      <CustomHeader title="생성한 매치 확인" />
+
+      <ScrollView
+        style={styles.scrollContainer}
+        contentContainerStyle={styles.scrollContent}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            colors={['#007AFF']}
+            tintColor="#007AFF"
+          />
+        }
+      >
+        {isLoading ? (
+          <View style={styles.loadingState}>
+            <Text style={styles.loadingText}>매치를 불러오는 중...</Text>
+          </View>
+        ) : error ? (
+          <View style={styles.errorState}>
+            <Text style={styles.errorText}>데이터를 불러올 수 없습니다</Text>
+          </View>
+        ) : (
+          <FlatList
+            data={createdMatches || []}
+            keyExtractor={(item, index) => String(item.waitingId ?? index)}
+            renderItem={renderMatchCard}
+            ListEmptyComponent={
+              <View style={styles.emptyState}>
+                <Text style={styles.emptyStateText}>
+                  생성된 매치가 없습니다
+                </Text>
+              </View>
+            }
+            scrollEnabled={false}
+            showsVerticalScrollIndicator={false}
+          />
+        )}
+      </ScrollView>
     </View>
   );
 }

--- a/src/screens/check_created_matches/index.tsx
+++ b/src/screens/check_created_matches/index.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function CheckCreatedMatchesScreen() {
+  return (
+    <View>
+      <Text>CheckCreatedMatchesScreen</Text>
+    </View>
+  );
+}

--- a/src/screens/home/components/envelope_section/index.tsx
+++ b/src/screens/home/components/envelope_section/index.tsx
@@ -48,6 +48,11 @@ export default memo(function EnvelopeSection({ teamId }: EnvelopeSectionProps) {
     router.push(ROUTES.CHECK_CREATED_MATCHES);
   };
 
+  const handleCheckAppliedMatches = () => {
+    if (!checkTeamMembership()) return;
+    router.push(ROUTES.CHECK_APPLIED_MATCHES);
+  };
+
   return (
     <>
       <View style={styles.envelopeSection}>
@@ -100,6 +105,26 @@ export default memo(function EnvelopeSection({ teamId }: EnvelopeSectionProps) {
               />
             </View>
             <Text style={styles.envelopeTitle}>생성한 매치 보기</Text>
+
+            <Ionicons
+              name="chevron-forward"
+              size={20}
+              color={theme.colors.text.sub}
+            />
+          </View>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.envelopeSection}>
+        <TouchableOpacity onPress={handleCheckAppliedMatches}>
+          <View style={styles.envelopeHeader}>
+            <View style={styles.envelopeIcon}>
+              <Image
+                source={require('@/assets/images/apply.png')}
+                style={{ width: 20, height: 20 }}
+              />
+            </View>
+            <Text style={styles.envelopeTitle}>신청한 매치 보기</Text>
 
             <Ionicons
               name="chevron-forward"

--- a/src/screens/home/components/envelope_section/index.tsx
+++ b/src/screens/home/components/envelope_section/index.tsx
@@ -43,6 +43,11 @@ export default memo(function EnvelopeSection({ teamId }: EnvelopeSectionProps) {
     });
   };
 
+  const handleCheckCreatedMatches = () => {
+    if (!checkTeamMembership()) return;
+    router.push(ROUTES.CHECK_CREATED_MATCHES);
+  };
+
   return (
     <>
       <View style={styles.envelopeSection}>
@@ -75,6 +80,26 @@ export default memo(function EnvelopeSection({ teamId }: EnvelopeSectionProps) {
               />
             </View>
             <Text style={styles.envelopeTitle}>매치 참여하기</Text>
+
+            <Ionicons
+              name="chevron-forward"
+              size={20}
+              color={theme.colors.text.sub}
+            />
+          </View>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.envelopeSection}>
+        <TouchableOpacity onPress={handleCheckCreatedMatches}>
+          <View style={styles.envelopeHeader}>
+            <View style={styles.envelopeIcon}>
+              <Image
+                source={require('@/assets/images/apply.png')}
+                style={{ width: 20, height: 20 }}
+              />
+            </View>
+            <Text style={styles.envelopeTitle}>생성한 매치 보기</Text>
 
             <Ionicons
               name="chevron-forward"

--- a/src/screens/match_application/components/match_card.tsx
+++ b/src/screens/match_application/components/match_card.tsx
@@ -88,7 +88,7 @@ export default function MatchCard({
           color: theme.colors.yellow[700],
           label: '대기 중',
         };
-      case 'REJECTED':
+      case 'CANCELED':
         return {
           bg: theme.colors.red[50],
           border: theme.colors.red[200],
@@ -212,23 +212,25 @@ export default function MatchCard({
       </View>
 
       <View style={styles.matchFooter}>
-        <TouchableOpacity
-          onPress={onPressRequest}
-          disabled={disabled}
-          style={[
-            styles.requestButton,
-            disabled && styles.requestButtonDisabled,
-            isCancellable && { backgroundColor: theme.colors.red[600] }, // ✅ 빨간색 적용
-          ]}
-        >
-          <Text style={styles.requestButtonText}>
-            {disabled
-              ? '요청 중...'
-              : isCancellable
-                ? '취소하기' // ✅ 텍스트 변경
-                : '신청하기'}
-          </Text>
-        </TouchableOpacity>
+        {!['CANCELED'].includes(match?.status?.toUpperCase?.() || '') && (
+          <TouchableOpacity
+            onPress={onPressRequest}
+            disabled={disabled}
+            style={[
+              styles.requestButton,
+              disabled && styles.requestButtonDisabled,
+              isCancellable && { backgroundColor: theme.colors.red[600] }, // ✅ 빨간색 적용
+            ]}
+          >
+            <Text style={styles.requestButtonText}>
+              {disabled
+                ? '요청 중...'
+                : isCancellable
+                  ? '취소하기'
+                  : '신청하기'}
+            </Text>
+          </TouchableOpacity>
+        )}
       </View>
     </View>
   );

--- a/src/screens/match_application/match_application_screen.tsx
+++ b/src/screens/match_application/match_application_screen.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
 import {
   View,
@@ -9,6 +10,7 @@ import {
 } from 'react-native';
 
 import { CustomHeader } from '@/src/components/ui/custom_header';
+import { ROUTES } from '@/src/constants/routes';
 import { useUserProfile } from '@/src/hooks/queries';
 import { useMatchRequest } from '@/src/hooks/useMatchRequest';
 import { useMatchWaitingList } from '@/src/hooks/useMatchWaitingList';
@@ -31,6 +33,8 @@ export default function MatchApplicationScreen({
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [selectedTime, setSelectedTime] = useState<Date | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+
+  const router = useRouter();
 
   const { data: userProfile, error: profileError, refetch } = useUserProfile();
 
@@ -85,7 +89,13 @@ export default function MatchApplicationScreen({
           Alert.alert(
             '신청 완료',
             `매치 요청이 전송되었습니다.\n상태: ${res.status}`,
-            [{ text: '확인', style: 'default' }]
+            [
+              {
+                text: '확인',
+                style: 'default',
+                onPress: () => router.push(ROUTES.HOME),
+              },
+            ]
           );
         },
         onError: () => {

--- a/src/screens/match_application/match_application_style.ts
+++ b/src/screens/match_application/match_application_style.ts
@@ -356,4 +356,16 @@ export const styles = StyleSheet.create({
   bottomSpacing: {
     height: theme.spacing.spacing6,
   },
+
+  statusBadge: {
+    paddingHorizontal: theme.spacing.spacing2,
+    paddingVertical: theme.spacing.spacing1,
+    borderRadius: theme.spacing.spacing2,
+    borderWidth: 1,
+    marginLeft: theme.spacing.spacing2,
+  },
+  statusBadgeText: {
+    fontSize: theme.typography.fontSize.font2,
+    fontWeight: theme.typography.fontWeight.semibold,
+  },
 });

--- a/src/screens/match_making/match_info/match_info_screen.tsx
+++ b/src/screens/match_making/match_info/match_info_screen.tsx
@@ -73,23 +73,14 @@ export default function MatchInfoScreen() {
 
   const pad2 = (n: number) => String(n).padStart(2, '0');
   const fmtDate = (d: Date) => {
-    console.log('fmtDate 호출됨, 입력 Date:', d);
-    console.log('d.getMonth():', d.getMonth());
-    console.log('d.getDate():', d.getDate());
-    console.log('d.getFullYear():', d.getFullYear());
     const result = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
-    console.log('fmtDate 결과:', result);
+
     return result;
   };
   const fmtTime = (d: Date) =>
     `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
 
   const onSubmit = async () => {
-    console.log('onSubmit 함수 호출됨');
-    console.log('현재 date 상태:', date);
-    console.log('date.toISOString():', date.toISOString());
-    console.log('fmtDate(date):', fmtDate(date));
-
     if (!selectedStadium) {
       Alert.alert('안내', '경기장을 선택해주세요.');
       return;
@@ -122,11 +113,6 @@ export default function MatchInfoScreen() {
       universityOnly,
       message,
     };
-
-    console.log('매치 생성 요청 데이터:');
-    console.log('선택된 날짜 객체:', date);
-    console.log('포맷된 날짜:', fmtDate(date));
-    console.log('전체 payload:', payload);
 
     createMatch(payload, {
       onSuccess: data => {
@@ -176,7 +162,6 @@ export default function MatchInfoScreen() {
             <TouchableOpacity
               style={style.dateTimeButton}
               onPress={() => {
-                console.log('날짜 선택 버튼 클릭됨');
                 setShowDatePicker(true);
               }}
             >
@@ -330,10 +315,6 @@ export default function MatchInfoScreen() {
         visible={showDatePicker}
         value={date}
         onDateChange={newDate => {
-          console.log('ModalDatePicker에서 날짜 변경됨:', newDate);
-          console.log('새로운 날짜의 getDate():', newDate.getDate());
-          console.log('새로운 날짜의 getMonth():', newDate.getMonth());
-          console.log('새로운 날짜의 getFullYear():', newDate.getFullYear());
           setDate(newDate);
         }}
         onClose={() => setShowDatePicker(false)}

--- a/src/screens/match_making/match_info/match_info_screen.tsx
+++ b/src/screens/match_making/match_info/match_info_screen.tsx
@@ -72,12 +72,24 @@ export default function MatchInfoScreen() {
   };
 
   const pad2 = (n: number) => String(n).padStart(2, '0');
-  const fmtDate = (d: Date) =>
-    `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+  const fmtDate = (d: Date) => {
+    console.log('fmtDate 호출됨, 입력 Date:', d);
+    console.log('d.getMonth():', d.getMonth());
+    console.log('d.getDate():', d.getDate());
+    console.log('d.getFullYear():', d.getFullYear());
+    const result = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+    console.log('fmtDate 결과:', result);
+    return result;
+  };
   const fmtTime = (d: Date) =>
     `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
 
   const onSubmit = async () => {
+    console.log('onSubmit 함수 호출됨');
+    console.log('현재 date 상태:', date);
+    console.log('date.toISOString():', date.toISOString());
+    console.log('fmtDate(date):', fmtDate(date));
+
     if (!selectedStadium) {
       Alert.alert('안내', '경기장을 선택해주세요.');
       return;
@@ -110,6 +122,11 @@ export default function MatchInfoScreen() {
       universityOnly,
       message,
     };
+
+    console.log('매치 생성 요청 데이터:');
+    console.log('선택된 날짜 객체:', date);
+    console.log('포맷된 날짜:', fmtDate(date));
+    console.log('전체 payload:', payload);
 
     createMatch(payload, {
       onSuccess: data => {
@@ -158,7 +175,10 @@ export default function MatchInfoScreen() {
           <View style={style.dateTimeContainer}>
             <TouchableOpacity
               style={style.dateTimeButton}
-              onPress={() => setShowDatePicker(true)}
+              onPress={() => {
+                console.log('날짜 선택 버튼 클릭됨');
+                setShowDatePicker(true);
+              }}
             >
               <Text style={style.dateTimeLabel}>날짜</Text>
               <Text style={style.dateTimeValue}>
@@ -309,7 +329,13 @@ export default function MatchInfoScreen() {
       <ModalDatePicker
         visible={showDatePicker}
         value={date}
-        onDateChange={setDate}
+        onDateChange={newDate => {
+          console.log('ModalDatePicker에서 날짜 변경됨:', newDate);
+          console.log('새로운 날짜의 getDate():', newDate.getDate());
+          console.log('새로운 날짜의 getMonth():', newDate.getMonth());
+          console.log('새로운 날짜의 getFullYear():', newDate.getFullYear());
+          setDate(newDate);
+        }}
         onClose={() => setShowDatePicker(false)}
         title="경기 날짜 선택"
       />

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -117,3 +117,11 @@ export interface MatchConfirmedResponseDto {
   venueId: number;
   status: string;
 }
+
+export interface MatchWaitingCancelResponseDto {
+  waitingId: number;
+  teamId: number;
+  teamName: string;
+  status: 'WAITING' | 'MATCHED' | 'REJECTED' | 'CANCELLED';
+  expiresAt: string;
+}

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -125,3 +125,14 @@ export interface MatchWaitingCancelResponseDto {
   status: 'WAITING' | 'MATCHED' | 'REJECTED' | 'CANCELLED';
   expiresAt: string;
 }
+
+export interface MatchWaitingHistoryResponseDto {
+  requestId: number;
+  requestTeamId: number;
+  requestTeamName: string | { name: string };
+  targetTeamId: number;
+  targetTeamName: string | { name: string };
+  requestMessage: string;
+  requestAt: string;
+  status?: 'PENDING' | 'APPROVED' | 'REJECTED' | 'CANCELED';
+}

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -60,7 +60,7 @@ export interface MatchWaitingResponseDto {
   skillLevelMax: 'AMATEUR' | 'SEMI_PRO' | 'PRO';
   universityOnly: boolean;
   message: string;
-  status: 'WAITING' | 'MATCHED' | 'CANCELLED';
+  status: 'WAITING' | 'MATCHED' | 'CANCELLED' | 'COMPLETED';
   expiresAt: string;
 }
 


### PR DESCRIPTION
### ✨ 작업 내용
- 내 팀이 **생성한** 매치 조회 페이지 구현
- 내 팀이 **생성한** 매치 취소 UI 구현 및 api 연동
- 매치 생성 시 내 팀이 생성한 매치에 바로 반영
- 내 팀이 **신청한** 매치 조회 페이지 구현
- 내 팀이 **신청한** 매치 취소 UI 구현 및 api 연동

### 🔧 변경 이유
- 매치 생성 시 생성 매치 조회 페이지에서 새로고침 해야만 반영 되던 것을 수정
- 매치 신청 버튼 선택 시 홈으로 리다이렉션 -> 기존 페이지에 머물 이유가 있나? **피드백 필요**
