### PR TITLE
refactor: 매치 삭제시 에러 해결

### DIFF
--- a/src/api/match.ts
+++ b/src/api/match.ts
@@ -146,7 +146,7 @@ export async function getMyCreatedMatches(): Promise<
     // content 배열만 리턴
     return response.content || [];
   } catch (error) {
-    console.error('❌ getMyCreatedMatches API 에러:', error);
+    console.error('getMyCreatedMatches API 에러:', error);
     throw error;
   }
 }
@@ -171,10 +171,9 @@ export async function getMyAppliedMatches(): Promise<
       last: boolean;
     }>(MATCH_REQUEST_API.GET_MY_APPLIED_MATCHES);
 
-    // content 배열만 리턴
     return response.content || [];
   } catch (error) {
-    console.error('❌ getMyAppliedMatches API 에러:', error);
+    console.error('getMyAppliedMatches API 에러:', error);
     throw error;
   }
 }
@@ -187,7 +186,7 @@ export async function cancelMatchRequestById(
     const response = await apiClient.delete<MatchRequestResponseDto>(url);
     return response;
   } catch (error) {
-    console.error('❌ cancelMatchRequestById API 에러:', error);
+    console.error('cancelMatchRequestById API 에러:', error);
     throw error;
   }
 }

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -29,8 +29,6 @@ import type {
   JoinWaitingCancelRequest,
   ApiUserJoinWaitingPageResponse,
   UserJoinWaitingPageResponse,
-  ApiUserJoinWaitingItem,
-  UserJoinWaitingItem,
 } from '@/src/types/team';
 import {
   transformTeamListPageResponse,

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -41,6 +41,7 @@ import {
   transformUserJoinWaitingPageResponse,
   getTeamTypeInEnglish,
   getSkillLevelInEnglish,
+  getRoleInKorean,
 } from '@/src/utils/team';
 
 export const createTeam = (data: CreateTeamRequest) => {
@@ -114,7 +115,7 @@ export const teamMemberApi = {
     return apiClient.put<TeamMember>(
       TEAM_MEMBER_API.UPDATE_ROLE(teamId, userId),
       {
-        role,
+        role: getRoleInKorean(role),
       }
     );
   },
@@ -125,6 +126,16 @@ export const teamMemberApi = {
   ): Promise<{ success: boolean; message: string }> => {
     return apiClient.delete<{ success: boolean; message: string }>(
       TEAM_MEMBER_API.REMOVE_MEMBER(teamId, userId)
+    );
+  },
+
+  delegateLeadership: (
+    teamId: string | number,
+    memberId: string | number
+  ): Promise<TeamMember> => {
+    return apiClient.post<TeamMember>(
+      TEAM_MEMBER_API.DELEGATE_LEADERSHIP(teamId, memberId),
+      {}
     );
   },
 };
@@ -245,15 +256,15 @@ export const teamDeleteApi = {
       let matchRequests = null;
       try {
         matchRequests = await apiClient.get('/api/matches/receive/me/pending');
-      } catch {
-        // 매치 요청 조회 실패
+      } catch (error) {
+        console.log('[팀 삭제 API] 매치 요청 조회 실패:', error);
       }
 
       let recentMatches = null;
       try {
         recentMatches = await apiClient.get('/api/teams/me/matches');
-      } catch {
-        // 최근 매치 조회 실패
+      } catch (error) {
+        console.log('[팀 삭제 API] 최근 매치 조회 실패:', error);
       }
 
       let matchWaiting = null;
@@ -261,8 +272,8 @@ export const teamDeleteApi = {
         matchWaiting = await apiClient.get(
           `/api/matches/waiting?teamId=${teamId}`
         );
-      } catch {
-        // 매치 대기 목록 조회 실패
+      } catch (error) {
+        console.log('[팀 삭제 API] 매치 대기 목록 조회 실패:', error);
       }
 
       const result = {

--- a/src/components/auth/team_guard.tsx
+++ b/src/components/auth/team_guard.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { View, Text, TouchableOpacity, Alert } from 'react-native';
 
 import { ROUTES } from '@/src/constants/routes';
+import { useAuth } from '@/src/contexts/auth_context';
 import { useUserProfile } from '@/src/hooks/queries';
 
 interface TeamGuardProps {
@@ -12,9 +13,15 @@ interface TeamGuardProps {
 
 export function TeamGuard({ children, fallbackMessage }: TeamGuardProps) {
   const router = useRouter();
+  const { isAuthenticated } = useAuth();
   const { data: userProfile, isLoading } = useUserProfile();
 
   useEffect(() => {
+    // 인증되지 않은 사용자는 TeamGuard를 실행하지 않음
+    if (!isAuthenticated) {
+      return;
+    }
+
     if (!isLoading && (!userProfile?.teamId || userProfile.teamId === null)) {
       Alert.alert(
         '팀 참여 필요',
@@ -31,12 +38,23 @@ export function TeamGuard({ children, fallbackMessage }: TeamGuardProps) {
           {
             text: '취소',
             style: 'cancel',
-            onPress: () => router.back(),
+            onPress: () => router.replace('/(tabs)'),
           },
         ]
       );
     }
-  }, [userProfile?.teamId, isLoading, router, fallbackMessage]);
+  }, [
+    userProfile?.teamId,
+    isLoading,
+    router,
+    fallbackMessage,
+    isAuthenticated,
+  ]);
+
+  // 인증되지 않은 사용자는 TeamGuard를 실행하지 않음
+  if (!isAuthenticated) {
+    return <>{children}</>;
+  }
 
   if (isLoading) {
     return (
@@ -93,7 +111,7 @@ export function TeamGuard({ children, fallbackMessage }: TeamGuardProps) {
           </TouchableOpacity>
 
           <TouchableOpacity
-            onPress={() => router.back()}
+            onPress={() => router.replace('/(tabs)')}
             style={{
               paddingHorizontal: 24,
               paddingVertical: 12,
@@ -102,7 +120,7 @@ export function TeamGuard({ children, fallbackMessage }: TeamGuardProps) {
               borderColor: '#ddd',
             }}
           >
-            <Text style={{ textAlign: 'center' }}>이전 페이지로</Text>
+            <Text style={{ textAlign: 'center' }}>홈으로 이동</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/src/components/team/modals/join_requests_modal.tsx
+++ b/src/components/team/modals/join_requests_modal.tsx
@@ -1,15 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
-import React, { useState } from 'react';
-import {
-  View,
-  Text,
-  ScrollView,
-  TouchableOpacity,
-  Modal,
-  TextInput,
-  Alert,
-  Platform,
-} from 'react-native';
+import React from 'react';
+import { View, Text, ScrollView, TouchableOpacity, Modal } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { colors } from '@/src/theme';

--- a/src/components/team/sections/member_list_section.tsx
+++ b/src/components/team/sections/member_list_section.tsx
@@ -14,6 +14,7 @@ interface MemberListSectionProps {
   onMemberPress: (member: TeamMember) => void;
   onRoleChange: (member: TeamMember) => void;
   onRemoveMember: (member: TeamMember) => void;
+  onDelegateLeadership: (member: TeamMember) => void;
 }
 
 export default memo(function MemberListSection({
@@ -22,6 +23,7 @@ export default memo(function MemberListSection({
   onMemberPress,
   onRoleChange,
   onRemoveMember,
+  onDelegateLeadership,
 }: MemberListSectionProps) {
   const getRoleColor = (role: TeamMemberRole): string => {
     switch (role) {
@@ -80,48 +82,80 @@ export default memo(function MemberListSection({
               </View>
             </View>
 
-            {member.role !== 'LEADER' &&
-              currentUserMember &&
-              (currentUserMember.role === 'LEADER' ||
-                (currentUserMember.role === 'VICE_LEADER' &&
-                  member.role === 'MEMBER')) && (
-                <View style={styles.memberActions}>
-                  <TouchableOpacity
-                    style={styles.actionButton}
-                    onPress={() => onRoleChange(member)}
-                  >
-                    <Ionicons
-                      name="swap-horizontal-outline"
-                      size={18}
-                      color={theme.colors.blue[600]}
-                    />
-                    <Text
-                      style={styles.actionButtonText}
-                      numberOfLines={1}
-                      ellipsizeMode="tail"
+            {currentUserMember && (
+              <View style={styles.memberActions}>
+                {/* 회장만 보이는 리더십 위임 버튼 */}
+                {currentUserMember.role === 'LEADER' &&
+                  member.role !== 'LEADER' && (
+                    <TouchableOpacity
+                      style={[styles.actionButton, styles.delegateButton]}
+                      onPress={() => onDelegateLeadership(member)}
                     >
-                      역할변경
-                    </Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.actionButton, styles.removeButton]}
-                    onPress={() => onRemoveMember(member)}
-                  >
-                    <Ionicons
-                      name="trash-outline"
-                      size={18}
-                      color={theme.colors.red[600]}
-                    />
-                    <Text
-                      style={[styles.actionButtonText, styles.removeButtonText]}
-                      numberOfLines={1}
-                      ellipsizeMode="tail"
+                      <Text
+                        style={[
+                          styles.actionButtonText,
+                          styles.delegateButtonText,
+                        ]}
+                        numberOfLines={1}
+                        ellipsizeMode="tail"
+                      >
+                        회장위임
+                      </Text>
+                    </TouchableOpacity>
+                  )}
+
+                {/* 역할 변경 버튼 */}
+                {member.role !== 'LEADER' &&
+                  (currentUserMember.role === 'LEADER' ||
+                    (currentUserMember.role === 'VICE_LEADER' &&
+                      member.role === 'MEMBER')) && (
+                    <TouchableOpacity
+                      style={styles.actionButton}
+                      onPress={() => onRoleChange(member)}
                     >
-                      강퇴
-                    </Text>
-                  </TouchableOpacity>
-                </View>
-              )}
+                      <Ionicons
+                        name="swap-horizontal-outline"
+                        size={18}
+                        color={theme.colors.blue[600]}
+                      />
+                      <Text
+                        style={styles.actionButtonText}
+                        numberOfLines={1}
+                        ellipsizeMode="tail"
+                      >
+                        역할변경
+                      </Text>
+                    </TouchableOpacity>
+                  )}
+
+                {/* 강퇴 버튼 */}
+                {member.role !== 'LEADER' &&
+                  (currentUserMember.role === 'LEADER' ||
+                    (currentUserMember.role === 'VICE_LEADER' &&
+                      member.role === 'MEMBER')) && (
+                    <TouchableOpacity
+                      style={[styles.actionButton, styles.removeButton]}
+                      onPress={() => onRemoveMember(member)}
+                    >
+                      <Ionicons
+                        name="trash-outline"
+                        size={18}
+                        color={theme.colors.red[600]}
+                      />
+                      <Text
+                        style={[
+                          styles.actionButtonText,
+                          styles.removeButtonText,
+                        ]}
+                        numberOfLines={1}
+                        ellipsizeMode="tail"
+                      >
+                        강퇴
+                      </Text>
+                    </TouchableOpacity>
+                  )}
+              </View>
+            )}
           </TouchableOpacity>
         ))}
 

--- a/src/components/team/sections/member_list_section_styles.ts
+++ b/src/components/team/sections/member_list_section_styles.ts
@@ -205,6 +205,15 @@ export const styles = StyleSheet.create({
     fontWeight: typography.fontWeight.semibold,
     flexShrink: 1,
   },
+  delegateButton: {
+    backgroundColor: colors.yellow[50],
+    borderColor: colors.yellow[300],
+  },
+  delegateButtonText: {
+    color: colors.yellow[600],
+    fontWeight: typography.fontWeight.semibold,
+    flexShrink: 1,
+  },
 
   emptyState: {
     alignItems: 'center',

--- a/src/components/ui/modal_date_picker.tsx
+++ b/src/components/ui/modal_date_picker.tsx
@@ -74,7 +74,7 @@ export const ModalDatePicker: React.FC<ModalDatePickerProps> = ({
     if (selectedDay > daysInNewMonth) {
       setSelectedDay(daysInNewMonth);
     }
-  }, [selectedMonth, selectedDay]);
+  }, [selectedMonth, selectedDay, currentYear]);
 
   return (
     <Modal

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -52,6 +52,8 @@ export const TEAM_MEMBER_API = {
     `/api/teams/${teamId}/users/${userId}`,
   REMOVE_MEMBER: (teamId: string | number, userId: string | number) =>
     `/api/teams/${teamId}/users/${userId}`,
+  DELEGATE_LEADERSHIP: (teamId: string | number, memberId: string | number) =>
+    `/api/teams/${teamId}/members/${memberId}/delegate-leadership`,
 };
 
 export const TEAM_MATCH_API = {

--- a/src/features/team_join/index.tsx
+++ b/src/features/team_join/index.tsx
@@ -181,7 +181,7 @@ export default function UniversityTeamListScreen() {
 
   if (loading && !data) {
     return (
-      <View style={styles.container}>
+      <View style={styles.loadingContainer}>
         <ActivityIndicator size="large" color={theme.colors.blue[500]} />
       </View>
     );

--- a/src/hooks/queries.ts
+++ b/src/hooks/queries.ts
@@ -449,13 +449,15 @@ export function useUpdateTeamMutation() {
 
 export function useDeleteTeamMutation() {
   return useMutation({
-    mutationFn: (teamId: string | number) =>
-      api.teamDeleteApi.deleteTeam(teamId),
+    mutationFn: (teamId: string | number) => {
+      return api.teamDeleteApi.deleteTeam(teamId);
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queries.userProfile.key });
+      queryClient.invalidateQueries({ queryKey: ['team'] });
+      queryClient.invalidateQueries({ queryKey: ['teamMembers'] });
     },
     onError: (error: unknown) => {
-      console.error('팀 삭제 실패:', error);
+      console.error('[팀 삭제 Mutation] API 실패:', error);
     },
   });
 }
@@ -471,6 +473,29 @@ export function useTeamExitMutation() {
     },
     onError: (error: unknown) => {
       console.error('팀 나가기 실패:', error);
+    },
+  });
+}
+
+export function useDelegateLeadershipMutation() {
+  return useMutation({
+    mutationFn: ({
+      teamId,
+      memberId,
+    }: {
+      teamId: string | number;
+      memberId: string | number;
+    }) => api.teamMemberApi.delegateLeadership(teamId, memberId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['teamMembers', variables.teamId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: queries.team.key(variables.teamId),
+      });
+    },
+    onError: (error: unknown) => {
+      console.error('리더십 위임 실패:', error);
     },
   });
 }

--- a/src/hooks/useCancelMatch.ts
+++ b/src/hooks/useCancelMatch.ts
@@ -16,6 +16,8 @@ export const useCancelMatch = () => {
       queryClient.invalidateQueries({
         queryKey: ['my-created-matches'], // ✅ v5 호환 문법
       });
+      // 사용자 프로필도 갱신 (팀 정보가 변경될 수 있음)
+      queryClient.invalidateQueries({ queryKey: ['user', 'profile'] });
     },
   });
 };

--- a/src/hooks/useCancelMatchRequest.ts
+++ b/src/hooks/useCancelMatchRequest.ts
@@ -13,6 +13,8 @@ export const useCancelMatchRequest = () => {
     onSuccess: () => {
       // 요청 목록 다시 갱신
       queryClient.invalidateQueries({ queryKey: ['my-applied-matches'] });
+      // 사용자 프로필도 갱신 (팀 정보가 변경될 수 있음)
+      queryClient.invalidateQueries({ queryKey: ['user', 'profile'] });
     },
   });
 };

--- a/src/lib/api_client.ts
+++ b/src/lib/api_client.ts
@@ -55,7 +55,15 @@ class ApiClient {
     } catch (error: unknown) {
       if (isAxiosError(error) && error.response) {
         if (error.response.status === 401 && this.onTokenExpired) {
-          this.onTokenExpired();
+          const isTeamDeleteRequest =
+            endpoint.includes('/api/teams/') && options.method === 'DELETE';
+          if (!isTeamDeleteRequest) {
+            this.onTokenExpired();
+          } else {
+            console.log(
+              '[API Client] 팀 삭제 요청이므로 토큰 만료 처리 건너뜀'
+            );
+          }
         }
 
         const errorData = error.response.data || {};

--- a/src/screens/auth/register/account_setup.tsx
+++ b/src/screens/auth/register/account_setup.tsx
@@ -8,7 +8,6 @@ import {
   Linking,
   TouchableWithoutFeedback,
   Keyboard,
-  useWindowDimensions,
 } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 

--- a/src/screens/home/components/envelope_section/index.tsx
+++ b/src/screens/home/components/envelope_section/index.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react';
 import { Alert, Image, Text, TouchableOpacity, View } from 'react-native';
 
 import { ROUTES } from '@/src/constants/routes';
+import { useAuth } from '@/src/contexts/auth_context';
 import { theme } from '@/src/theme';
 
 import styles from '../../home_style';
@@ -13,7 +14,14 @@ interface EnvelopeSectionProps {
 }
 
 export default memo(function EnvelopeSection({ teamId }: EnvelopeSectionProps) {
+  const { isAuthenticated } = useAuth();
+
   const checkTeamMembership = () => {
+    // 인증되지 않은 사용자는 팀 참여 필요 알림을 표시하지 않음
+    if (!isAuthenticated) {
+      return false;
+    }
+
     if (!teamId || teamId === null || teamId === undefined) {
       Alert.alert(
         '팀 참여 필요',

--- a/src/screens/match_making/match_info/component/skill_level_selector/skill_level_selector.tsx
+++ b/src/screens/match_making/match_info/component/skill_level_selector/skill_level_selector.tsx
@@ -1,13 +1,8 @@
 import React, { useState } from 'react';
-import { View, Text, Dimensions } from 'react-native';
+import { View, Text } from 'react-native';
 import { Dropdown } from 'react-native-element-dropdown';
 
-import { theme } from '@/src/theme';
-
 import { style } from './skill_level_selector_style';
-
-const { width: screenWidth } = Dimensions.get('window');
-const isTablet = screenWidth >= 768;
 
 // 실력 레벨 정의
 const LEVELS = [

--- a/src/screens/team/guide/components/header/index.tsx
+++ b/src/screens/team/guide/components/header/index.tsx
@@ -10,9 +10,13 @@ import { styles } from '../../team_guide_styles';
 export default memo(function Header() {
   const router = useRouter();
 
+  const handleBackPress = () => {
+    router.replace('/(tabs)');
+  };
+
   return (
     <>
-      <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+      <TouchableOpacity style={styles.backButton} onPress={handleBackPress}>
         <Ionicons name="chevron-back" size={24} color={colors.text.white} />
       </TouchableOpacity>
 

--- a/src/screens/team/join/university_team_list_screen.tsx
+++ b/src/screens/team/join/university_team_list_screen.tsx
@@ -43,8 +43,7 @@ export default function UniversityTeamListScreen() {
   const slideAnim = useState(new Animated.Value(0))[0];
   const joinModalAnim = useState(new Animated.Value(0))[0];
 
-  const { joinWaiting, isJoining, joinError, joinSuccess, resetJoinState } =
-    useTeamJoinRequest();
+  const { joinWaiting } = useTeamJoinRequest();
 
   const {
     data,
@@ -153,7 +152,7 @@ export default function UniversityTeamListScreen() {
             ]
           );
         });
-      } catch (error) {
+      } catch {
         Alert.alert(
           '신청 실패',
           '팀 가입 신청에 실패했습니다. 다시 시도해주세요.',

--- a/src/screens/team/join/university_team_list_screen.tsx
+++ b/src/screens/team/join/university_team_list_screen.tsx
@@ -197,7 +197,7 @@ export default function UniversityTeamListScreen() {
 
   if (loading && !data) {
     return (
-      <View style={styles.container}>
+      <View style={styles.loadingContainer}>
         <ActivityIndicator size="large" color={theme.colors.blue[500]} />
       </View>
     );

--- a/src/screens/team/join/university_team_list_style.ts
+++ b/src/screens/team/join/university_team_list_style.ts
@@ -48,8 +48,8 @@ export const styles = StyleSheet.create({
   teamCard: {
     backgroundColor: theme.colors.background.sub,
     borderRadius: theme.spacing.spacing3,
-    padding: theme.spacing.spacing5,
-    marginBottom: theme.spacing.spacing4,
+    padding: theme.spacing.spacing4,
+    marginBottom: theme.spacing.spacing3,
     borderWidth: 1,
     borderColor: theme.colors.border.light,
   },
@@ -57,7 +57,7 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
-    marginBottom: theme.spacing.spacing3,
+    marginBottom: theme.spacing.spacing2,
   },
   teamName: {
     fontSize: theme.typography.fontSize.font5,
@@ -77,21 +77,21 @@ export const styles = StyleSheet.create({
     fontWeight: theme.typography.fontWeight.medium,
   },
   teamDescription: {
-    fontSize: theme.typography.fontSize.font4,
+    fontSize: theme.typography.fontSize.font3,
     color: theme.colors.text.sub,
-    lineHeight: theme.typography.lineHeight.line6,
-    marginBottom: theme.spacing.spacing4,
+    lineHeight: theme.typography.lineHeight.line5,
+    marginBottom: theme.spacing.spacing3,
   },
   teamInfo: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginBottom: theme.spacing.spacing4,
+    marginBottom: theme.spacing.spacing3,
     paddingHorizontal: theme.spacing.spacing1,
   },
   infoItem: {
     flex: 1,
     alignItems: 'center',
-    paddingVertical: theme.spacing.spacing2,
+    paddingVertical: theme.spacing.spacing1,
   },
   infoLabel: {
     fontSize: theme.typography.fontSize.font2,
@@ -107,12 +107,12 @@ export const styles = StyleSheet.create({
   joinButton: {
     backgroundColor: theme.colors.blue[500],
     borderRadius: theme.spacing.spacing2,
-    paddingVertical: theme.spacing.spacing3,
+    paddingVertical: theme.spacing.spacing2,
     alignItems: 'center',
     opacity: 0.8,
   },
   joinButtonText: {
-    fontSize: theme.typography.fontSize.font4,
+    fontSize: theme.typography.fontSize.font3,
     fontWeight: theme.typography.fontWeight.semibold,
     color: theme.colors.white,
   },

--- a/src/screens/team/management/team_management_screen.tsx
+++ b/src/screens/team/management/team_management_screen.tsx
@@ -192,7 +192,20 @@ export default function TeamManagementScreen({
             isTeamLeader={currentUserMember?.role === 'LEADER'}
           />
           <TeamMembersSection
-            teamMembers={teamMembers}
+            teamMembers={teamMembers.sort((a, b) => {
+              // 역할 우선순위: 회장(1) > 부회장(2) > 일반멤버(3)
+              const roleOrder = { LEADER: 1, VICE_LEADER: 2, MEMBER: 3 };
+              const aOrder = roleOrder[a.role] || 3;
+              const bOrder = roleOrder[b.role] || 3;
+
+              // 역할이 다르면 역할 순서로 정렬
+              if (aOrder !== bOrder) {
+                return aOrder - bOrder;
+              }
+
+              // 같은 역할이면 이름순으로 정렬
+              return a.name.localeCompare(b.name);
+            })}
             membersLoading={membersLoading}
             onMemberPress={handleMemberPress}
           />

--- a/src/screens/team/management/team_member_screen.tsx
+++ b/src/screens/team/management/team_member_screen.tsx
@@ -12,6 +12,7 @@ import {
   useTeamMembers,
   useRemoveMemberMutation,
   useUpdateMemberRoleMutation,
+  useDelegateLeadershipMutation,
   useUserProfile,
 } from '@/src/hooks/queries';
 import type { TeamMember, TeamMemberRole } from '@/src/types/team';
@@ -41,6 +42,7 @@ export default function MemberManagementScreen({
 
   const removeMemberMutation = useRemoveMemberMutation();
   const updateMemberRoleMutation = useUpdateMemberRoleMutation();
+  const delegateLeadershipMutation = useDelegateLeadershipMutation();
 
   if (!teamId || teamId === null || teamId === undefined) {
     return (
@@ -94,10 +96,42 @@ export default function MemberManagementScreen({
   };
 
   const handleRoleChange = (member: TeamMember) => {
+    const teamMembersData = teamMembers?.content || [];
+    const currentUserMember = teamMembersData.find(
+      m => m.name === userProfile?.name
+    );
+
+    if (!currentUserMember) {
+      Alert.alert('오류', '현재 사용자 정보를 찾을 수 없습니다.');
+      return;
+    }
+
+    // 회장/부회장만 역할 변경 가능
+    if (
+      currentUserMember.role !== 'LEADER' &&
+      currentUserMember.role !== 'VICE_LEADER'
+    ) {
+      Alert.alert(
+        '권한 없음',
+        '회장과 부회장만 팀원의 역할을 변경할 수 있습니다.'
+      );
+      return;
+    }
+
+    // 자기 자신의 역할은 변경할 수 없음
+    if (member.userId === currentUserMember.userId) {
+      Alert.alert(
+        '알림',
+        '회장/부회장은 자신의 역할을 직접 변경할 수 없습니다.'
+      );
+      return;
+    }
+
     if (member.role === 'LEADER') {
       Alert.alert('알림', '회장의 역할은 변경할 수 없습니다.');
       return;
     }
+
     setSelectedMember(member);
     setShowRoleModal(true);
   };
@@ -133,10 +167,51 @@ export default function MemberManagementScreen({
                 },
                 onError: error => {
                   console.error('역할 변경 실패:', error);
-                  Alert.alert(
-                    '오류',
-                    '역할 변경에 실패했습니다. 다시 시도해주세요.'
-                  );
+
+                  let errorMessage =
+                    '역할 변경에 실패했습니다. 다시 시도해주세요.';
+
+                  if (error && typeof error === 'object' && 'status' in error) {
+                    const apiError = error as {
+                      status: number;
+                      message?: string;
+                      data?: any;
+                    };
+
+                    if (apiError.status === 401) {
+                      errorMessage = '인증이 필요합니다. 다시 로그인해주세요.';
+                    } else if (apiError.status === 403) {
+                      if (apiError.message?.includes('NO_PERMISSION')) {
+                        errorMessage =
+                          '역할 변경 권한이 없습니다. 회장과 부회장만 변경할 수 있습니다.';
+                      } else if (
+                        apiError.message?.includes(
+                          'SELF_DELEGATION_NOT_ALLOWED'
+                        )
+                      ) {
+                        errorMessage =
+                          '회장/부회장은 자신의 역할을 직접 변경할 수 없습니다.';
+                      } else {
+                        errorMessage = '역할 변경 권한이 없습니다.';
+                      }
+                    } else if (apiError.status === 404) {
+                      if (apiError.message?.includes('TEAM_NOT_FOUND')) {
+                        errorMessage = '팀을 찾을 수 없습니다.';
+                      } else if (
+                        apiError.message?.includes('TEAM_MEMBER_NOT_FOUND')
+                      ) {
+                        errorMessage = '팀원을 찾을 수 없습니다.';
+                      } else {
+                        errorMessage = '요청한 정보를 찾을 수 없습니다.';
+                      }
+                    } else if (apiError.status === 400) {
+                      errorMessage = '유효하지 않은 역할입니다.';
+                    } else if (apiError.message) {
+                      errorMessage = apiError.message;
+                    }
+                  }
+
+                  Alert.alert('오류', errorMessage);
                 },
               }
             );
@@ -147,7 +222,6 @@ export default function MemberManagementScreen({
   };
 
   const handleRemoveMember = (member: TeamMember) => {
-    // 현재 사용자의 팀 멤버 정보 찾기
     const teamMembersData = teamMembers?.content || [];
     const currentUserMember = teamMembersData.find(
       m => m.name === userProfile?.name
@@ -158,7 +232,6 @@ export default function MemberManagementScreen({
       return;
     }
 
-    // 권한 체크: LEADER와 VICE_LEADER만 강퇴 권한 있음
     if (
       currentUserMember.role !== 'LEADER' &&
       currentUserMember.role !== 'VICE_LEADER'
@@ -167,15 +240,12 @@ export default function MemberManagementScreen({
       return;
     }
 
-    // 회장은 누구도 강퇴할 수 없음
     if (member.role === 'LEADER') {
       Alert.alert('알림', '회장은 강퇴할 수 없습니다.');
       return;
     }
 
-    // 권한 규칙 체크
     if (currentUserMember.role === 'VICE_LEADER') {
-      // 부회장은 일반 멤버만 추방 가능
       if (member.role !== 'MEMBER') {
         Alert.alert('권한 없음', '부회장은 일반 멤버만 강퇴할 수 있습니다.');
         return;
@@ -212,7 +282,6 @@ export default function MemberManagementScreen({
                 onError: error => {
                   console.error('팀원 강퇴 실패:', error);
 
-                  // 에러 메시지 파싱
                   let errorMessage =
                     '팀원 강퇴에 실패했습니다. 다시 시도해주세요.';
 
@@ -243,6 +312,94 @@ export default function MemberManagementScreen({
     );
   };
 
+  const handleDelegateLeadership = (member: TeamMember) => {
+    const teamMembersData = teamMembers?.content || [];
+    const currentUserMember = teamMembersData.find(
+      m => m.name === userProfile?.name
+    );
+
+    if (!currentUserMember) {
+      Alert.alert('오류', '현재 사용자 정보를 찾을 수 없습니다.');
+      return;
+    }
+
+    if (currentUserMember.role !== 'LEADER') {
+      Alert.alert('권한 없음', '회장만 리더십을 위임할 수 있습니다.');
+      return;
+    }
+
+    if (member.userId === currentUserMember.userId) {
+      Alert.alert('알림', '자기 자신에게는 리더십을 위임할 수 없습니다.');
+      return;
+    }
+
+    if (member.role === 'LEADER') {
+      Alert.alert('알림', '이미 회장인 멤버에게는 위임할 수 없습니다.');
+      return;
+    }
+
+    if (!numericTeamId || !member.userId) {
+      Alert.alert('오류', '팀 정보 또는 사용자 정보가 올바르지 않습니다.');
+      return;
+    }
+
+    Alert.alert(
+      '리더십 위임',
+      `${member.name}님에게 회장 자리를 위임하시겠습니까?\n\n위임 후 현재 회장은 일반 멤버가 되고, ${member.name}님이 새로운 회장이 됩니다.`,
+      [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '위임',
+          style: 'destructive',
+          onPress: () => {
+            delegateLeadershipMutation.mutate(
+              {
+                teamId: numericTeamId,
+                memberId: member.id,
+              },
+              {
+                onSuccess: () => {
+                  Alert.alert('성공', '리더십이 성공적으로 위임되었습니다.');
+                  refetch();
+                },
+                onError: error => {
+                  console.error('리더십 위임 실패:', error);
+
+                  let errorMessage =
+                    '리더십 위임에 실패했습니다. 다시 시도해주세요.';
+
+                  if (error && typeof error === 'object' && 'status' in error) {
+                    const apiError = error as {
+                      status: number;
+                      message?: string;
+                      data?: any;
+                    };
+
+                    if (apiError.status === 403) {
+                      errorMessage =
+                        '리더십 위임 권한이 없습니다. 회장만 위임할 수 있습니다.';
+                    } else if (apiError.status === 404) {
+                      errorMessage = '팀원을 찾을 수 없습니다.';
+                    } else if (apiError.status === 409) {
+                      errorMessage =
+                        '자기 자신에게는 리더십을 위임할 수 없습니다.';
+                    } else if (apiError.status === 400) {
+                      errorMessage = '대상 멤버가 다른 팀에 속해있습니다.';
+                    } else if (apiError.message) {
+                      errorMessage = apiError.message;
+                    }
+                  }
+
+                  Alert.alert('오류', errorMessage);
+                },
+              }
+            );
+          },
+        },
+      ]
+    );
+  };
+
   return (
     <View style={styles.container}>
       <CustomHeader title="팀원 관리" />
@@ -256,13 +413,27 @@ export default function MemberManagementScreen({
         <View style={styles.contentContainer}>
           <MemberInfoCard />
           <MemberListSection
-            teamMembers={teamMembers.content}
+            teamMembers={teamMembers.content.sort((a, b) => {
+              // 역할 우선순위: 회장(1) > 부회장(2) > 일반멤버(3)
+              const roleOrder = { LEADER: 1, VICE_LEADER: 2, MEMBER: 3 };
+              const aOrder = roleOrder[a.role] || 3;
+              const bOrder = roleOrder[b.role] || 3;
+
+              // 역할이 다르면 역할 순서로 정렬
+              if (aOrder !== bOrder) {
+                return aOrder - bOrder;
+              }
+
+              // 같은 역할이면 이름순으로 정렬
+              return a.name.localeCompare(b.name);
+            })}
             currentUserMember={teamMembers.content.find(
               m => m.name === userProfile?.name
             )}
             onMemberPress={handleMemberPress}
             onRoleChange={handleRoleChange}
             onRemoveMember={handleRemoveMember}
+            onDelegateLeadership={handleDelegateLeadership}
           />
         </View>
       </ScrollView>

--- a/src/utils/team.ts
+++ b/src/utils/team.ts
@@ -109,9 +109,18 @@ export const getRoleDisplayName = (role: TeamMemberRole): string => {
   const roleMapping: Record<TeamMemberRole, string> = {
     LEADER: '회장',
     VICE_LEADER: '부회장',
-    MEMBER: '팀원',
+    MEMBER: '일반멤버',
   };
-  return roleMapping[role] || '팀원';
+  return roleMapping[role] || '일반멤버';
+};
+
+export const getRoleInKorean = (role: TeamMemberRole): string => {
+  const roleMapping: Record<TeamMemberRole, string> = {
+    LEADER: '회장',
+    VICE_LEADER: '부회장',
+    MEMBER: '일반멤버',
+  };
+  return roleMapping[role] || '일반멤버';
 };
 
 export const JOIN_REQUEST_STATUS_MAPPING: Record<


### PR DESCRIPTION
## **PR 설명**

### **참고사항**
- 주요 목적: 인증되지 않은 사용자에 대한 팀 관련 로직 개선 및 UI/UX 최적화
- 영향 범위: 팀 가드, 팀 조인 화면, 매치 취소 로직, 홈 화면

## **코드 개선**

**문제점**: 
- 인증되지 않은 사용자도 팀 가드가 실행되어 불필요한 알림이 표시됨
- 로그인하지 않은 상태에서 팀 참여 관련 알림이 나타나는 UX 문제

**해결방법**:
- 인증 상태 확인 로직 추가하여 인증되지 않은 사용자는 팀 가드를 실행하지 않도록 수정
- `useAuth` 훅을 사용하여 인증 상태를 확인하고, 인증되지 않은 경우 컴포넌트를 그대로 렌더링

**고민한 점**: 
- 인증 상태를 확인하는 시점을 `useEffect` 내부와 컴포넌트 렌더링 시점 모두에서 처리
- 사용자 경험을 위해 인증되지 않은 상태에서는 팀 관련 알림을 표시하지 않도록 설계

### **UI/UX 최적화**
**파일**: `src/screens/team/join/university_team_list_style.ts`

**문제점**: 
- 팀 카드가 너무 크게 표시되어 화면에 적은 수의 카드만 보임
- 사용자가 스크롤을 많이 해야 하는 불편함

**해결방법**:
- 카드 패딩을 `spacing5`에서 `spacing4`로 축소
- 카드 간 마진을 `spacing4`에서 `spacing3`으로 축소
- 팀 설명 폰트 크기를 `font4`에서 `font3`으로 축소
- 라인 높이와 마진을 적절히 조정하여 더 컴팩트한 레이아웃 구현
- 버튼 크기와 텍스트 크기도 함께 축소

**고민한 점**:
- 가독성을 유지하면서도 공간 효율성을 높이는 균형점 찾기
- 각 요소별로 적절한 크기 조정을 통해 전체적인 일관성 유지

### **데이터 동기화 개선**
**파일**: `src/hooks/useCancelMatch.ts`, `src/hooks/useCancelMatchRequest.ts`

**문제점**: 
- 매치 취소 후 사용자 프로필 정보가 즉시 반영되지 않음
- 팀 정보 변경사항이 다른 화면에 지연되어 표시되는 문제

**해결방법**:
- 매치 취소 성공 시 사용자 프로필 쿼리도 함께 무효화하도록 추가
- 기존의 매치 관련 쿼리 무효화와 함께 프로필 정보도 갱신하여 데이터 일관성 확보

**고민한 점**:
- 성능과 데이터 일관성 사이의 균형 고려
- 필요한 최소한의 쿼리만 무효화하여 불필요한 네트워크 요청 방지

### **로딩 상태 개선**
**파일**: `src/features/team_join/index.tsx`, `src/screens/team/join/university_team_list_screen.tsx`

**문제점**: 
- 로딩 상태에서 부적절한 컨테이너 스타일 사용
- 일관되지 않은 로딩 UI

**해결방법**:
- 로딩 상태에서 `styles.container` 대신 `styles.loadingContainer` 사용
- 로딩 화면에 적합한 스타일을 적용하여 일관된 사용자 경험 제공

**고민한 점**:
- 로딩 상태에서 사용자에게 적절한 피드백을 제공하는 방법
- 전체 화면을 차지하는 로딩과 부분 로딩의 구분

**문제점**: 
- 팀 참여 거부 시 이전 페이지로 돌아가는 것이 사용자에게 혼란을 줄 수 있음
- 명확한 다음 액션 가이드 부족

**해결방법**:
- 팀 참여 거부 시 홈 화면으로 이동하도록 `router.replace` 사용
- 버튼 텍스트를 "이전 페이지로"에서 "홈으로 이동"으로 변경하여 명확한 액션 안내

**고민한 점**:
- 사용자가 팀 참여를 거부했을 때 가장 적절한 다음 액션은 무엇인지
- `router.back()`과 `router.replace()` 중 어떤 것이 더 나은 UX인지